### PR TITLE
Don't remove blank lines around braces.

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -2160,10 +2160,10 @@ nl_between_get_set              = 0        # unsigned number
 nl_property_brace               = ignore   # ignore/add/remove/force
 
 # Whether to remove blank lines after '{'.
-eat_blanks_after_open_brace     = true    # true/false
+eat_blanks_after_open_brace     = false    # true/false
 
 # Whether to remove blank lines before '}'.
-eat_blanks_before_close_brace   = true    # true/false
+eat_blanks_before_close_brace   = false    # true/false
 
 # How aggressively to remove extra newlines not in preprocessor.
 #


### PR DESCRIPTION
Changing two parameters that made the following code change

| original | uncrustified |
|---------|-------------|
|<pre>namespace foo {<br><br>constexpr size_t bar = 0;<br><br>} // namespace foo</pre>|<pre>namespace foo {<br>constexpr size_t bar = 0;<br>} // namespace foo</pre>|