### PR TITLE
Fix access modifiers indentation.

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1168,7 +1168,7 @@ indent_label                    = 1        # number
 # <=0: Subtract from brace indent
 #
 # Default: 1
-indent_access_spec              = 1        # number
+indent_access_spec              = -4        # number
 
 # Whether to indent the code after an access specifier by one level.
 # If true, this option forces 'indent_access_spec=0'.


### PR DESCRIPTION
Access modifiers should go under the class brace, not at first column.