### PR TITLE
Newline between try/catch and braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,29 @@ if (!error)
 if (!error) return success;
 ```
 
+### Try - catch blocks
+
+Both the opening and closing braces in a try or catch block should be each alone in their own new line.
+
+```c++
+// Correct
+try
+{
+    foo();
+}
+catch
+{
+    error();
+}
+
+// Incorrect
+try {
+    foo();
+} catch {
+    error();
+}
+```
+
 ### Pointer and Reference Expressions
 
 When declaring a pointer or reference variable, the `*` or `&` must be always adjacent to the type and separated from the variable name by a space.

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1482,7 +1482,7 @@ nl_brace_finally                = ignore   # ignore/add/remove/force
 nl_finally_brace                = ignore   # ignore/add/remove/force
 
 # Add or remove newline between 'try' and '{'.
-nl_try_brace                    = ignore   # ignore/add/remove/force
+nl_try_brace                    = add   # ignore/add/remove/force
 
 # Add or remove newline between get/set and '{'.
 nl_getset_brace                 = ignore   # ignore/add/remove/force
@@ -1492,7 +1492,7 @@ nl_for_brace                    = add      # ignore/add/remove/force
 
 # Add or remove newline before the '{' of a 'catch' statement, as in
 # 'catch (decl) <here> {'.
-nl_catch_brace                  = ignore   # ignore/add/remove/force
+nl_catch_brace                  = add   # ignore/add/remove/force
 
 # (OC) Add or remove newline before the '{' of a '@catch' statement, as in
 # '@catch (decl) <here> {'. If set to ignore, nl_catch_brace is used.


### PR DESCRIPTION
change:
```
try {
    foo();
}
catch {
    error();
}
```
into
```
try
{
    foo();
}
catch
{
    error();
}
```
