### PR TITLE
[23011] Correct style on cpp `do-while` loops

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1976,6 +1976,12 @@ nl_split_for_one_liner          = false    # true/false
 # adding a newline, as in 'while (expr) <here> stmt;'.
 nl_split_while_one_liner        = false    # true/false
 
+# Newline between do and open brace
+nl_do_brace                     = add      # string (add/force/ignore/remove)
+
+# Newline between close brace and while
+nl_brace_while                  = add      # string (add/force/ignore/remove)
+
 #
 # Blank line options
 #


### PR DESCRIPTION
This PR adds a couple of configuration options to the linter that corrects the CPP style `do-while` loops. 