### PR TITLE
[#23611] Uncrustify in Ubuntu 24.04 raises deprecation warnings with eProsima uncrustify.cfg

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1052,7 +1052,7 @@ indent_var_def_cont             = false    # true/false
 
 # Whether to indent continued shift expressions ('<<' and '>>') instead of
 # aligning. Set align_left_shift=false when enabling this.
-indent_shift                    = false    # true/false
+indent_shift                    = 0        # true:1/false:0
 
 # Whether to force indentation of function definitions to start in column 1.
 indent_func_def_force_col1      = false    # true/false
@@ -1199,11 +1199,11 @@ indent_paren_after_func_call    = false    # true/false
 
 # Whether to indent a comma when inside a parenthesis.
 # If true, aligns under the open parenthesis.
-indent_comma_paren              = false    # true/false
+indent_comma_paren              = 0        # true:1/false:0
 
 # Whether to indent a Boolean operator when inside a parenthesis.
 # If true, aligns under the open parenthesis.
-indent_bool_paren               = false    # true/false
+indent_bool_paren               = 0        # true:1/false:0
 
 # Whether to indent a semicolon when inside a for parenthesis.
 # If true, aligns under the open for parenthesis.
@@ -2538,7 +2538,7 @@ align_oc_msg_spec_span          = 0        # unsigned number
 
 # Whether to align macros wrapped with a backslash and a newline. This will
 # not work right if the macro contains a multi-line comment.
-align_nl_cont                   = false    # true/false
+align_nl_cont                   = 0        # true:1/false:0
 
 # Whether to align macro functions and variables together.
 align_pp_define_together        = false    # true/false
@@ -2727,7 +2727,7 @@ mod_full_brace_if               = add      # ignore/add/remove/force
 # blocks.
 #
 # Overrides mod_full_brace_if.
-mod_full_brace_if_chain         = false    # true/false
+mod_full_brace_if_chain         = 0        # true:1/false:0
 
 # Whether to add braces to all blocks of an 'if'/'else if'/'else' chain.
 # If true, mod_full_brace_if_chain will only remove braces from an 'if' that
@@ -2947,7 +2947,7 @@ pp_indent_extern                = true     # true/false
 # inside of.
 #
 # Default: true
-pp_indent_brace                 = true     # true/false
+pp_indent_brace                 = 1        # true:1/false:0
 
 #
 # Sort includes options

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -405,7 +405,7 @@ sp_before_ellipsis              = ignore   # ignore/add/remove/force
 sp_type_ellipsis                = ignore   # ignore/add/remove/force
 
 # (D) Add or remove space between a type and '?'.
-sp_type_question                = ignore   # ignore/add/remove/force
+sp_before_ptr_star              = ignore   # ignore/add/remove/force
 
 # Add or remove space between ')' and '...'.
 sp_paren_ellipsis               = ignore   # ignore/add/remove/force
@@ -899,10 +899,10 @@ sp_inside_newop_paren_open      = ignore   # ignore/add/remove/force
 sp_inside_newop_paren_close     = ignore   # ignore/add/remove/force
 
 # Add or remove space before a trailing or embedded comment.
-sp_before_tr_emb_cmt            = ignore   # ignore/add/remove/force
+sp_before_tr_cmt                = ignore   # ignore/add/remove/force
 
 # Number of spaces before a trailing or embedded comment.
-sp_num_before_tr_emb_cmt        = 0        # unsigned number
+sp_num_before_tr_cmt            = 0        # unsigned number
 
 # (Java) Add or remove space between an annotation and the open parenthesis.
 sp_annotation_paren             = ignore   # ignore/add/remove/force
@@ -1118,7 +1118,7 @@ indent_member                   = indent_continue        # unsigned number
 indent_member_single            = false    # true/false
 
 # Spaces to indent single line ('//') comments on lines before code.
-indent_sing_line_comments       = 0        # unsigned number
+indent_single_line_comments_before = 0        # unsigned number
 
 # When opening a paren for a control statement (if, for, while, etc), increase
 # the indent level by this value. Negative values decrease the indent level.
@@ -2044,7 +2044,7 @@ nl_after_func_body_one_liner    = 0        # unsigned number
 # of a function body.
 #
 # 0: No change (default).
-nl_func_var_def_blk             = 0        # unsigned number
+nl_var_def_blk_end_func_top     = 0        # unsigned number
 
 # The number of newlines before a block of typedefs. If nl_after_access_spec
 # is non-zero, that option takes precedence.
@@ -2892,7 +2892,7 @@ pp_indent_at_level              = false    # true/false
 pp_indent_count                 = 1        # unsigned number
 
 # Add or remove space after # based on pp_level of #if blocks.
-pp_space                        = ignore   # ignore/add/remove/force
+pp_space_after                  = ignore   # ignore/add/remove/force
 
 # Sets the number of spaces per level added with pp_space.
 pp_space_count                  = 0        # unsigned number

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,4 +1,4 @@
-# Uncrustify-0.71.0_f
+# Uncrustify-0.78.1_f
 
 #
 # General options
@@ -37,18 +37,16 @@ string_replace_tab_chars        = false    # true/false
 # Improvements to template detection may make this option obsolete.
 tok_split_gte                   = false    # true/false
 
-# Disable formatting of NL_CONT ('\\n') ended lines (e.g. multiline macros)
+# Disable formatting of NL_CONT ('\\n') ended lines (e.g. multi-line macros).
 disable_processing_nl_cont      = false    # true/false
 
 # Specify the marker used in comments to disable processing of part of the
 # file.
-# The comment should be used alone in one line.
 #
 # Default:  *INDENT-OFF*
 disable_processing_cmt          = " *INDENT-OFF*"      # string
 
 # Specify the marker used in comments to (re)enable processing in a file.
-# The comment should be used alone in one line.
 #
 # Default:  *INDENT-ON*
 enable_processing_cmt           = " *INDENT-ON*"     # string
@@ -56,8 +54,14 @@ enable_processing_cmt           = " *INDENT-ON*"     # string
 # Enable parsing of digraphs.
 enable_digraphs                 = false    # true/false
 
+# Option to allow both disable_processing_cmt and enable_processing_cmt
+# strings, if specified, to be interpreted as ECMAScript regular expressions.
+# If true, a regex search will be performed within comments according to the
+# specified patterns in order to disable/enable processing.
+processing_cmt_as_regex         = false    # true/false
+
 # Add or remove the UTF-8 BOM (recommend 'remove').
-utf8_bom                        = ignore   # ignore/add/remove/force
+utf8_bom                        = ignore   # ignore/add/remove/force/not_defined
 
 # If the file contains bytes with values between 128 and 255, but is not
 # UTF-8, then output as UTF-8.
@@ -70,851 +74,1051 @@ utf8_force                      = false    # true/false
 # Spacing options
 #
 
-# Add or remove space between 'do' and '{'.
-sp_do_brace_open                = ignore   # ignore/add/remove/force
-
-# Add or remove space between '}' and 'while'.
-sp_brace_close_while            = ignore   # ignore/add/remove/force
-
-# Add or remove space between 'while' and '('.
-sp_while_paren_open             = add   # ignore/add/remove/force
-
 # Add or remove space around non-assignment symbolic operators ('+', '/', '%',
 # '<<', and so forth).
-sp_arith                        = add      # ignore/add/remove/force
+sp_arith                        = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space around arithmetic operators '+' and '-'.
 #
 # Overrides sp_arith.
-sp_arith_additive               = add      # ignore/add/remove/force
+sp_arith_additive               = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space around assignment operator '=', '+=', etc.
-sp_assign                       = add      # ignore/add/remove/force
+sp_assign                       = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space around '=' in C++11 lambda capture specifications.
 #
 # Overrides sp_assign.
-sp_cpp_lambda_assign            = remove   # ignore/add/remove/force
+sp_cpp_lambda_assign            = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the capture specification of a C++11 lambda when
 # an argument list is present, as in '[] <here> (int x){ ... }'.
-sp_cpp_lambda_square_paren      = remove   # ignore/add/remove/force
+sp_cpp_lambda_square_paren      = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the capture specification of a C++11 lambda with
 # no argument list is present, as in '[] <here> { ... }'.
-sp_cpp_lambda_square_brace      = ignore   # ignore/add/remove/force
+sp_cpp_lambda_square_brace      = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after the opening parenthesis and before the closing
+# parenthesis of a argument list of a C++11 lambda, as in
+# '[]( <here> ){ ... }'
+# with an empty list.
+sp_cpp_lambda_argument_list_empty = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after the opening parenthesis and before the closing
+# parenthesis of a argument list of a C++11 lambda, as in
+# '[]( <here> int x <here> ){ ... }'.
+sp_cpp_lambda_argument_list     = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the argument list of a C++11 lambda, as in
 # '[](int x) <here> { ... }'.
-sp_cpp_lambda_paren_brace       = ignore   # ignore/add/remove/force
+sp_cpp_lambda_paren_brace       = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a lambda body and its call operator of an
 # immediately invoked lambda, as in '[]( ... ){ ... } <here> ( ... )'.
-sp_cpp_lambda_fparen            = ignore   # ignore/add/remove/force
+sp_cpp_lambda_fparen            = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around assignment operator '=' in a prototype.
 #
 # If set to ignore, use sp_assign.
-sp_assign_default               = ignore   # ignore/add/remove/force
+sp_assign_default               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before assignment operator '=', '+=', etc.
 #
 # Overrides sp_assign.
-sp_before_assign                = ignore   # ignore/add/remove/force
+sp_before_assign                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after assignment operator '=', '+=', etc.
 #
 # Overrides sp_assign.
-sp_after_assign                 = ignore   # ignore/add/remove/force
+sp_after_assign                 = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space in 'enum {'.
+#
+# Default: add
+sp_enum_brace                   = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space in 'NS_ENUM ('.
-sp_enum_paren                   = ignore   # ignore/add/remove/force
+sp_enum_paren                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around assignment '=' in enum.
-sp_enum_assign                  = ignore   # ignore/add/remove/force
+sp_enum_assign                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before assignment '=' in enum.
 #
 # Overrides sp_enum_assign.
-sp_enum_before_assign           = ignore   # ignore/add/remove/force
+sp_enum_before_assign           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after assignment '=' in enum.
 #
 # Overrides sp_enum_assign.
-sp_enum_after_assign            = ignore   # ignore/add/remove/force
+sp_enum_after_assign            = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around assignment ':' in enum.
-sp_enum_colon                   = ignore   # ignore/add/remove/force
+sp_enum_colon                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around preprocessor '##' concatenation operator.
 #
 # Default: add
-sp_pp_concat                    = add      # ignore/add/remove/force
+sp_pp_concat                    = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space after preprocessor '#' stringify operator.
 # Also affects the '#@' charizing operator.
-sp_pp_stringify                 = ignore   # ignore/add/remove/force
+sp_pp_stringify                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before preprocessor '#' stringify operator
 # as in '#define x(y) L#y'.
-sp_before_pp_stringify          = ignore   # ignore/add/remove/force
+sp_before_pp_stringify          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around boolean operators '&&' and '||'.
-sp_bool                         = add      # ignore/add/remove/force
+sp_bool                         = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space around compare operator '<', '>', '==', etc.
-sp_compare                      = add      # ignore/add/remove/force
+sp_compare                      = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '(' and ')'.
-sp_inside_paren                 = ignore   # ignore/add/remove/force
+sp_inside_paren                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between nested parentheses, i.e. '((' vs. ') )'.
-sp_paren_paren                  = remove   # ignore/add/remove/force
+sp_paren_paren                  = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between back-to-back parentheses, i.e. ')(' vs. ') ('.
-sp_cparen_oparen                = ignore   # ignore/add/remove/force
+sp_cparen_oparen                = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to balance spaces inside nested parentheses.
 sp_balance_nested_parens        = false    # true/false
 
 # Add or remove space between ')' and '{'.
-sp_paren_brace                  = ignore   # ignore/add/remove/force
+sp_paren_brace                  = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space between nested braces, i.e. '{{' vs '{ {'.
-sp_brace_brace                  = ignore   # ignore/add/remove/force
+# Add or remove space between nested braces, i.e. '{{' vs. '{ {'.
+sp_brace_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before pointer star '*'.
-sp_before_ptr_star              = remove   # ignore/add/remove/force
+sp_before_ptr_star              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before pointer star '*' that isn't followed by a
 # variable name. If set to ignore, sp_before_ptr_star is used instead.
-sp_before_unnamed_ptr_star      = remove   # ignore/add/remove/force
+sp_before_unnamed_ptr_star      = remove   # ignore/add/remove/force/not_defined
 
-# Add or remove space between pointer stars '*'.
-sp_between_ptr_star             = remove   # ignore/add/remove/force
+# Add or remove space before pointer star '*' that is followed by a qualifier.
+# If set to ignore, sp_before_unnamed_ptr_star is used instead.
+sp_before_qualifier_ptr_star    = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space before pointer star '*' that is followed by 'operator' keyword.
+# If set to ignore, sp_before_unnamed_ptr_star is used instead.
+sp_before_operator_ptr_star     = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space before pointer star '*' that is followed by
+# a class scope (as in 'int *MyClass::method()') or namespace scope
+# (as in 'int *my_ns::func()').
+# If set to ignore, sp_before_unnamed_ptr_star is used instead.
+sp_before_scope_ptr_star        = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space before pointer star '*' that is followed by '::',
+# as in 'int *::func()'.
+# If set to ignore, sp_before_unnamed_ptr_star is used instead.
+sp_before_global_scope_ptr_star = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between a qualifier and a pointer star '*' that isn't
+# followed by a variable name, as in '(char const *)'. If set to ignore,
+# sp_before_ptr_star is used instead.
+sp_qualifier_unnamed_ptr_star   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between pointer stars '*', as in 'int ***a;'.
+sp_between_ptr_star             = remove   # ignore/add/remove/force/not_defined
+
+# Add or remove space between pointer star '*' and reference '&', as in 'int *& a;'.
+sp_between_ptr_ref              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after pointer star '*', if followed by a word.
 #
 # Overrides sp_type_func.
-sp_after_ptr_star               = add      # ignore/add/remove/force
+sp_after_ptr_star               = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space after pointer caret '^', if followed by a word.
-sp_after_ptr_block_caret        = ignore   # ignore/add/remove/force
+sp_after_ptr_block_caret        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after pointer star '*', if followed by a qualifier.
-sp_after_ptr_star_qualifier     = ignore   # ignore/add/remove/force
+sp_after_ptr_star_qualifier     = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after a pointer star '*', if followed by a function
 # prototype or function definition.
 #
 # Overrides sp_after_ptr_star and sp_type_func.
-sp_after_ptr_star_func          = ignore   # ignore/add/remove/force
+sp_after_ptr_star_func          = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after a pointer star '*' in the trailing return of a
+# function prototype or function definition.
+sp_after_ptr_star_trailing      = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between the pointer star '*' and the name of the variable
+# in a function pointer definition.
+sp_ptr_star_func_var            = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between the pointer star '*' and the name of the type
+# in a function pointer type definition.
+sp_ptr_star_func_type           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after a pointer star '*', if followed by an open
-# parenthesis, as in 'void* (*)().
-sp_ptr_star_paren               = ignore   # ignore/add/remove/force
+# parenthesis, as in 'void* (*)()'.
+sp_ptr_star_paren               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before a pointer star '*', if followed by a function
-# prototype or function definition.
-sp_before_ptr_star_func         = ignore   # ignore/add/remove/force
+# prototype or function definition. If set to ignore, sp_before_ptr_star is
+# used instead.
+sp_before_ptr_star_func         = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between a qualifier and a pointer star '*' followed by
+# the name of the function in a function prototype or definition, as in
+# 'char const *foo()`. If set to ignore, sp_before_ptr_star is used instead.
+sp_qualifier_ptr_star_func      = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space before a pointer star '*' in the trailing return of a
+# function prototype or function definition.
+sp_before_ptr_star_trailing     = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between a qualifier and a pointer star '*' in the
+# trailing return of a function prototype or function definition, as in
+# 'auto foo() -> char const *'.
+sp_qualifier_ptr_star_trailing  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before a reference sign '&'.
-sp_before_byref                 = remove   # ignore/add/remove/force
+sp_before_byref                 = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space before a reference sign '&' that isn't followed by a
 # variable name. If set to ignore, sp_before_byref is used instead.
-sp_before_unnamed_byref         = remove   # ignore/add/remove/force
+sp_before_unnamed_byref         = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after reference sign '&', if followed by a word.
 #
 # Overrides sp_type_func.
-sp_after_byref                  = add      # ignore/add/remove/force
+sp_after_byref                  = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space after a reference sign '&', if followed by a function
 # prototype or function definition.
 #
 # Overrides sp_after_byref and sp_type_func.
-sp_after_byref_func             = add   # ignore/add/remove/force
+sp_after_byref_func             = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space before a reference sign '&', if followed by a function
 # prototype or function definition.
-sp_before_byref_func            = remove   # ignore/add/remove/force
+sp_before_byref_func            = remove   # ignore/add/remove/force/not_defined
 
-# Add or remove space between type and word.
+# Add or remove space after a reference sign '&', if followed by an open
+# parenthesis, as in 'char& (*)()'.
+sp_byref_paren                  = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between type and word. In cases where total removal of
+# whitespace would be a syntax error, a value of 'remove' is treated the same
+# as 'force'.
+#
+# This also affects some other instances of space following a type that are
+# not covered by other options; for example, between the return type and
+# parenthesis of a function type template argument, between the type and
+# parenthesis of an array parameter, or between 'decltype(...)' and the
+# following word.
 #
 # Default: force
-sp_after_type                   = force    # ignore/add/remove/force
+sp_after_type                   = force    # ignore/add/remove/force/not_defined
 
-# Add or remove space between 'decltype(...)' and word.
-sp_after_decltype               = ignore   # ignore/add/remove/force
+# Add or remove space between 'decltype(...)' and word,
+# brace or function call.
+sp_after_decltype               = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove space before the parenthesis in the D constructs
 # 'template Foo(' and 'class Foo('.
-sp_before_template_paren        = ignore   # ignore/add/remove/force
+sp_before_template_paren        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'template' and '<'.
 # If set to ignore, sp_before_angle is used.
-sp_template_angle               = ignore   # ignore/add/remove/force
+sp_template_angle               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before '<'.
-sp_before_angle                 = ignore   # ignore/add/remove/force
+sp_before_angle                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '<' and '>'.
-sp_inside_angle                 = ignore   # ignore/add/remove/force
+sp_inside_angle                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '<>'.
-sp_inside_angle_empty           = ignore   # ignore/add/remove/force
+# if empty.
+sp_inside_angle_empty           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '>' and ':'.
-sp_angle_colon                  = ignore   # ignore/add/remove/force
+sp_angle_colon                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after '>'.
-sp_after_angle                  = ignore   # ignore/add/remove/force
+sp_after_angle                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '>' and '(' as found in 'new List<byte>(foo);'.
-sp_angle_paren                  = ignore   # ignore/add/remove/force
+sp_angle_paren                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '>' and '()' as found in 'new List<byte>();'.
-sp_angle_paren_empty            = ignore   # ignore/add/remove/force
+sp_angle_paren_empty            = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '>' and a word as in 'List<byte> m;' or
 # 'template <typename T> static ...'.
-sp_angle_word                   = ignore   # ignore/add/remove/force
+sp_angle_word                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '>' and '>' in '>>' (template stuff).
 #
 # Default: add
-sp_angle_shift                  = remove   # ignore/add/remove/force
+sp_angle_shift                  = remove   # ignore/add/remove/force/not_defined
 
 # (C++11) Permit removal of the space between '>>' in 'foo<bar<int> >'. Note
 # that sp_angle_shift cannot remove the space without this option.
-sp_permit_cpp11_shift           = true    # true/false
+sp_permit_cpp11_shift           = true     # true/false
 
 # Add or remove space before '(' of control statements ('if', 'for', 'switch',
 # 'while', etc.).
-sp_before_sparen                = add      # ignore/add/remove/force
+sp_before_sparen                = add      # ignore/add/remove/force/not_defined
 
-# Add or remove space inside '(' and ')' of control statements.
-sp_inside_sparen                = ignore   # ignore/add/remove/force
+# Add or remove space inside '(' and ')' of control statements other than
+# 'for'.
+sp_inside_sparen                = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space after '(' of control statements.
+# Add or remove space after '(' of control statements other than 'for'.
 #
 # Overrides sp_inside_sparen.
-sp_inside_sparen_open           = ignore   # ignore/add/remove/force
+sp_inside_sparen_open           = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space before ')' of control statements.
+# Add or remove space before ')' of control statements other than 'for'.
 #
 # Overrides sp_inside_sparen.
-sp_inside_sparen_close          = ignore   # ignore/add/remove/force
+sp_inside_sparen_close          = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space inside '(' and ')' of 'for' statements.
+sp_inside_for                   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after '(' of 'for' statements.
+#
+# Overrides sp_inside_for.
+sp_inside_for_open              = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space before ')' of 'for' statements.
+#
+# Overrides sp_inside_for.
+sp_inside_for_close             = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between '((' or '))' of control statements.
+sp_sparen_paren                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after ')' of control statements.
-sp_after_sparen                 = remove   # ignore/add/remove/force
+sp_after_sparen                 = remove   # ignore/add/remove/force/not_defined
 
-# Add or remove space between ')' and '{' of of control statements.
-sp_sparen_brace                 = ignore   # ignore/add/remove/force
+# Add or remove space between ')' and '{' of control statements.
+sp_sparen_brace                 = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between 'do' and '{'.
+sp_do_brace_open                = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between '}' and 'while'.
+sp_brace_close_while            = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between 'while' and '('. Overrides sp_before_sparen.
+sp_while_paren_open             = add      # ignore/add/remove/force/not_defined
 
 # (D) Add or remove space between 'invariant' and '('.
-sp_invariant_paren              = ignore   # ignore/add/remove/force
+sp_invariant_paren              = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove space after the ')' in 'invariant (C) c'.
-sp_after_invariant_paren        = ignore   # ignore/add/remove/force
+sp_after_invariant_paren        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before empty statement ';' on 'if', 'for' and 'while'.
-sp_special_semi                 = ignore   # ignore/add/remove/force
+sp_special_semi                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before ';'.
 #
 # Default: remove
-sp_before_semi                  = remove   # ignore/add/remove/force
+sp_before_semi                  = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space before ';' in non-empty 'for' statements.
-sp_before_semi_for              = ignore   # ignore/add/remove/force
+sp_before_semi_for              = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space before a semicolon of an empty part of a for statement.
-sp_before_semi_for_empty        = ignore   # ignore/add/remove/force
+# Add or remove space before a semicolon of an empty left part of a for
+# statement, as in 'for ( <here> ; ; )'.
+sp_before_semi_for_empty        = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between the semicolons of an empty middle part of a for
+# statement, as in 'for ( ; <here> ; )'.
+sp_between_semi_for_empty       = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after ';', except when followed by a comment.
 #
 # Default: add
-sp_after_semi                   = add      # ignore/add/remove/force
+sp_after_semi                   = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space after ';' in non-empty 'for' statements.
 #
 # Default: force
-sp_after_semi_for               = force    # ignore/add/remove/force
+sp_after_semi_for               = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space after the final semicolon of an empty part of a for
 # statement, as in 'for ( ; ; <here> )'.
-sp_after_semi_for_empty         = ignore   # ignore/add/remove/force
+sp_after_semi_for_empty         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before '[' (except '[]').
-sp_before_square                = ignore   # ignore/add/remove/force
+sp_before_square                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before '[' for a variable definition.
 #
 # Default: remove
-sp_before_vardef_square         = remove   # ignore/add/remove/force
+sp_before_vardef_square         = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space before '[' for asm block.
-sp_before_square_asm_block      = ignore   # ignore/add/remove/force
+sp_before_square_asm_block      = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before '[]'.
-sp_before_squares               = ignore   # ignore/add/remove/force
+sp_before_squares               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before C++17 structured bindings.
-sp_cpp_before_struct_binding    = ignore   # ignore/add/remove/force
+sp_cpp_before_struct_binding    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside a non-empty '[' and ']'.
-sp_inside_square                = ignore   # ignore/add/remove/force
+sp_inside_square                = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space inside '[]'.
+# if empty.
+sp_inside_square_empty          = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and
 # ']'. If set to ignore, sp_inside_square is used.
-sp_inside_square_oc_array       = ignore   # ignore/add/remove/force
+sp_inside_square_oc_array       = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after ',', i.e. 'a,b' vs. 'a, b'.
-sp_after_comma                  = add      # ignore/add/remove/force
+sp_after_comma                  = add      # ignore/add/remove/force/not_defined
 
-# Add or remove space before ','.
+# Add or remove space before ',', i.e. 'a,b' vs. 'a ,b'.
 #
 # Default: remove
-sp_before_comma                 = remove   # ignore/add/remove/force
+sp_before_comma                 = remove   # ignore/add/remove/force/not_defined
 
-# (C#) Add or remove space between ',' and ']' in multidimensional array type
+# (C#, Vala) Add or remove space between ',' and ']' in multidimensional array type
 # like 'int[,,]'.
-sp_after_mdatype_commas         = ignore   # ignore/add/remove/force
+sp_after_mdatype_commas         = ignore   # ignore/add/remove/force/not_defined
 
-# (C#) Add or remove space between '[' and ',' in multidimensional array type
+# (C#, Vala) Add or remove space between '[' and ',' in multidimensional array type
 # like 'int[,,]'.
-sp_before_mdatype_commas        = ignore   # ignore/add/remove/force
+sp_before_mdatype_commas        = ignore   # ignore/add/remove/force/not_defined
 
-# (C#) Add or remove space between ',' in multidimensional array type
+# (C#, Vala) Add or remove space between ',' in multidimensional array type
 # like 'int[,,]'.
-sp_between_mdatype_commas       = ignore   # ignore/add/remove/force
+sp_between_mdatype_commas       = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between an open parenthesis and comma,
 # i.e. '(,' vs. '( ,'.
 #
 # Default: force
-sp_paren_comma                  = force    # ignore/add/remove/force
+sp_paren_comma                  = force    # ignore/add/remove/force/not_defined
+
+# Add or remove space between a type and ':'.
+sp_type_colon                   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after the variadic '...' when preceded by a
+# non-punctuator.
+# The value REMOVE will be overridden with FORCE
+sp_after_ellipsis               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before the variadic '...' when preceded by a
 # non-punctuator.
-sp_before_ellipsis              = ignore   # ignore/add/remove/force
+# The value REMOVE will be overridden with FORCE
+sp_before_ellipsis              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a type and '...'.
-sp_type_ellipsis                = ignore   # ignore/add/remove/force
+sp_type_ellipsis                = ignore   # ignore/add/remove/force/not_defined
 
-# (D) Add or remove space between a type and '?'.
-sp_before_ptr_star              = ignore   # ignore/add/remove/force
+# Add or remove space between a '*' and '...'.
+sp_ptr_type_ellipsis            = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between ')' and '...'.
-sp_paren_ellipsis               = ignore   # ignore/add/remove/force
+sp_paren_ellipsis               = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between '&&' and '...'.
+sp_byref_ellipsis               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between ')' and a qualifier such as 'const'.
-sp_paren_qualifier              = ignore   # ignore/add/remove/force
+sp_paren_qualifier              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between ')' and 'noexcept'.
-sp_paren_noexcept               = ignore   # ignore/add/remove/force
+sp_paren_noexcept               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after class ':'.
-sp_after_class_colon            = ignore   # ignore/add/remove/force
+sp_after_class_colon            = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before class ':'.
-sp_before_class_colon           = ignore   # ignore/add/remove/force
+sp_before_class_colon           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after class constructor ':'.
-sp_after_constr_colon           = add      # ignore/add/remove/force
+#
+# Default: add
+sp_after_constr_colon           = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space before class constructor ':'.
-sp_before_constr_colon          = remove   # ignore/add/remove/force
+#
+# Default: add
+sp_before_constr_colon          = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space before case ':'.
 #
 # Default: remove
-sp_before_case_colon            = remove   # ignore/add/remove/force
+sp_before_case_colon            = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'operator' and operator sign.
-sp_after_operator               = add      # ignore/add/remove/force
+sp_after_operator               = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space between the operator symbol and the open parenthesis, as
 # in 'operator ++('.
-sp_after_operator_sym           = ignore   # ignore/add/remove/force
+sp_after_operator_sym           = ignore   # ignore/add/remove/force/not_defined
 
 # Overrides sp_after_operator_sym when the operator has no arguments, as in
 # 'operator *()'.
-sp_after_operator_sym_empty     = ignore   # ignore/add/remove/force
+sp_after_operator_sym_empty     = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after C/D cast, i.e. 'cast(int)a' vs. 'cast(int) a' or
 # '(int)a' vs. '(int) a'.
-sp_after_cast                   = ignore   # ignore/add/remove/force
+sp_after_cast                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove spaces inside cast parentheses.
-sp_inside_paren_cast            = ignore   # ignore/add/remove/force
+sp_inside_paren_cast            = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between the type and open parenthesis in a C++ cast,
 # i.e. 'int(exp)' vs. 'int (exp)'.
-sp_cpp_cast_paren               = ignore   # ignore/add/remove/force
+sp_cpp_cast_paren               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'sizeof' and '('.
-sp_sizeof_paren                 = ignore   # ignore/add/remove/force
+sp_sizeof_paren                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'sizeof' and '...'.
-sp_sizeof_ellipsis              = ignore   # ignore/add/remove/force
+sp_sizeof_ellipsis              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'sizeof...' and '('.
-sp_sizeof_ellipsis_paren        = ignore   # ignore/add/remove/force
+sp_sizeof_ellipsis_paren        = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between '...' and a parameter pack.
+sp_ellipsis_parameter_pack      = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between a parameter pack and '...'.
+sp_parameter_pack_ellipsis      = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'decltype' and '('.
-sp_decltype_paren               = ignore   # ignore/add/remove/force
+sp_decltype_paren               = ignore   # ignore/add/remove/force/not_defined
 
 # (Pawn) Add or remove space after the tag keyword.
-sp_after_tag                    = ignore   # ignore/add/remove/force
+sp_after_tag                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside enum '{' and '}'.
-sp_inside_braces_enum           = ignore   # ignore/add/remove/force
+sp_inside_braces_enum           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside struct/union '{' and '}'.
-sp_inside_braces_struct         = ignore   # ignore/add/remove/force
+sp_inside_braces_struct         = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space inside Objective-C boxed dictionary '{' and '}'
-sp_inside_braces_oc_dict        = ignore   # ignore/add/remove/force
+sp_inside_braces_oc_dict        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after open brace in an unnamed temporary
-# direct-list-initialization.
-sp_after_type_brace_init_lst_open = ignore   # ignore/add/remove/force
+# direct-list-initialization
+# if statement is a brace_init_lst
+# works only if sp_brace_brace is set to ignore.
+sp_after_type_brace_init_lst_open = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before close brace in an unnamed temporary
-# direct-list-initialization.
-sp_before_type_brace_init_lst_close = ignore   # ignore/add/remove/force
+# direct-list-initialization
+# if statement is a brace_init_lst
+# works only if sp_brace_brace is set to ignore.
+sp_before_type_brace_init_lst_close = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space inside an unnamed temporary direct-list-initialization.
-sp_inside_type_brace_init_lst   = ignore   # ignore/add/remove/force
+# Add or remove space inside an unnamed temporary direct-list-initialization
+# if statement is a brace_init_lst
+# works only if sp_brace_brace is set to ignore
+# works only if sp_before_type_brace_init_lst_close is set to ignore.
+sp_inside_type_brace_init_lst   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '{' and '}'.
-sp_inside_braces                = ignore   # ignore/add/remove/force
+sp_inside_braces                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '{}'.
-sp_inside_braces_empty          = ignore   # ignore/add/remove/force
+# if empty.
+sp_inside_braces_empty          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around trailing return operator '->'.
-sp_trailing_return              = ignore   # ignore/add/remove/force
+sp_trailing_return              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between return type and function name. A minimum of 1
 # is forced except for pointer return types.
-sp_type_func                    = ignore   # ignore/add/remove/force
+sp_type_func                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between type and open brace of an unnamed temporary
 # direct-list-initialization.
-sp_type_brace_init_lst          = ignore   # ignore/add/remove/force
+sp_type_brace_init_lst          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '(' on function declaration.
-sp_func_proto_paren             = ignore   # ignore/add/remove/force
+sp_func_proto_paren             = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '()' on function declaration
-# without parameters.
-sp_func_proto_paren_empty       = ignore   # ignore/add/remove/force
+# if empty.
+sp_func_proto_paren_empty       = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '(' with a typedef specifier.
-sp_func_type_paren              = ignore   # ignore/add/remove/force
+sp_func_type_paren              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between alias name and '(' of a non-pointer function type typedef.
-sp_func_def_paren               = ignore   # ignore/add/remove/force
+sp_func_def_paren               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '()' on function definition
-# without parameters.
-sp_func_def_paren_empty         = ignore   # ignore/add/remove/force
+# if empty.
+sp_func_def_paren_empty         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside empty function '()'.
 # Overrides sp_after_angle unless use_sp_after_angle_always is set to true.
-sp_inside_fparens               = ignore   # ignore/add/remove/force
+sp_inside_fparens               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside function '(' and ')'.
-sp_inside_fparen                = ignore   # ignore/add/remove/force
+sp_inside_fparen                = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space inside user functor '(' and ')'.
+sp_func_call_user_inside_rparen = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space inside empty functor '()'.
+# Overrides sp_after_angle unless use_sp_after_angle_always is set to true.
+sp_inside_rparens               = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space inside functor '(' and ')'.
+sp_inside_rparen                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside the first parentheses in a function type, as in
 # 'void (*x)(...)'.
-sp_inside_tparen                = ignore   # ignore/add/remove/force
+sp_inside_tparen                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between the ')' and '(' in a function type, as in
 # 'void (*x)(...)'.
-sp_after_tparen_close           = ignore   # ignore/add/remove/force
+sp_after_tparen_close           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between ']' and '(' when part of a function call.
-sp_square_fparen                = ignore   # ignore/add/remove/force
+sp_square_fparen                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between ')' and '{' of function.
-sp_fparen_brace                 = ignore   # ignore/add/remove/force
+sp_fparen_brace                 = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space between ')' and '{' of s function call in object
+# Add or remove space between ')' and '{' of a function call in object
 # initialization.
 #
 # Overrides sp_fparen_brace.
-sp_fparen_brace_initializer     = ignore   # ignore/add/remove/force
+sp_fparen_brace_initializer     = ignore   # ignore/add/remove/force/not_defined
 
 # (Java) Add or remove space between ')' and '{{' of double brace initializer.
-sp_fparen_dbrace                = ignore   # ignore/add/remove/force
+sp_fparen_dbrace                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '(' on function calls.
-sp_func_call_paren              = ignore   # ignore/add/remove/force
+sp_func_call_paren              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '()' on function calls without
 # parameters. If set to ignore (the default), sp_func_call_paren is used.
-sp_func_call_paren_empty        = ignore   # ignore/add/remove/force
+sp_func_call_paren_empty        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between the user function name and '(' on function
 # calls. You need to set a keyword to be a user function in the config file,
 # like:
 #   set func_call_user tr _ i18n
-sp_func_call_user_paren         = ignore   # ignore/add/remove/force
+sp_func_call_user_paren         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside user function '(' and ')'.
-sp_func_call_user_inside_fparen = ignore   # ignore/add/remove/force
+sp_func_call_user_inside_fparen = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between nested parentheses with user functions,
 # i.e. '((' vs. '( ('.
-sp_func_call_user_paren_paren   = ignore   # ignore/add/remove/force
+sp_func_call_user_paren_paren   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a constructor/destructor and the open
 # parenthesis.
-sp_func_class_paren             = ignore   # ignore/add/remove/force
+sp_func_class_paren             = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a constructor without parameters or destructor
 # and '()'.
-sp_func_class_paren_empty       = ignore   # ignore/add/remove/force
+sp_func_class_paren_empty       = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after 'return'.
+#
+# Default: force
+sp_return                       = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'return' and '('.
-sp_return_paren                 = ignore   # ignore/add/remove/force
+sp_return_paren                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'return' and '{'.
-sp_return_brace                 = ignore   # ignore/add/remove/force
+sp_return_brace                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '__attribute__' and '('.
-sp_attribute_paren              = ignore   # ignore/add/remove/force
+sp_attribute_paren              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'defined' and '(' in '#if defined (FOO)'.
-sp_defined_paren                = ignore   # ignore/add/remove/force
+sp_defined_paren                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'throw' and '(' in 'throw (something)'.
-sp_throw_paren                  = ignore   # ignore/add/remove/force
+sp_throw_paren                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'throw' and anything other than '(' as in
 # '@throw [...];'.
-sp_after_throw                  = ignore   # ignore/add/remove/force
+sp_after_throw                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'catch' and '(' in 'catch (something) { }'.
 # If set to ignore, sp_before_sparen is used.
-sp_catch_paren                  = ignore   # ignore/add/remove/force
+sp_catch_paren                  = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space between '@catch' and '('
 # in '@catch (something) { }'. If set to ignore, sp_catch_paren is used.
-sp_oc_catch_paren               = ignore   # ignore/add/remove/force
+sp_oc_catch_paren               = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space before Objective-C protocol list
 # as in '@protocol Protocol<here><Protocol_A>' or '@interface MyClass : NSObject<here><MyProtocol>'.
-sp_before_oc_proto_list         = ignore   # ignore/add/remove/force
+sp_before_oc_proto_list         = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space between class name and '('
 # in '@interface className(categoryName)<ProtocolName>:BaseClass'
-sp_oc_classname_paren           = ignore   # ignore/add/remove/force
+sp_oc_classname_paren           = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove space between 'version' and '('
 # in 'version (something) { }'. If set to ignore, sp_before_sparen is used.
-sp_version_paren                = ignore   # ignore/add/remove/force
+sp_version_paren                = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove space between 'scope' and '('
 # in 'scope (something) { }'. If set to ignore, sp_before_sparen is used.
-sp_scope_paren                  = ignore   # ignore/add/remove/force
+sp_scope_paren                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'super' and '(' in 'super (something)'.
 #
 # Default: remove
-sp_super_paren                  = remove   # ignore/add/remove/force
+sp_super_paren                  = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'this' and '(' in 'this (something)'.
 #
 # Default: remove
-sp_this_paren                   = remove   # ignore/add/remove/force
+sp_this_paren                   = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a macro name and its definition.
-sp_macro                        = ignore   # ignore/add/remove/force
+sp_macro                        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a macro function ')' and its definition.
-sp_macro_func                   = ignore   # ignore/add/remove/force
+sp_macro_func                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'else' and '{' if on the same line.
-sp_else_brace                   = ignore   # ignore/add/remove/force
+sp_else_brace                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '}' and 'else' if on the same line.
-sp_brace_else                   = ignore   # ignore/add/remove/force
+sp_brace_else                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '}' and the name of a typedef on the same line.
-sp_brace_typedef                = ignore   # ignore/add/remove/force
+sp_brace_typedef                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before the '{' of a 'catch' statement, if the '{' and
 # 'catch' are on the same line, as in 'catch (decl) <here> {'.
-sp_catch_brace                  = ignore   # ignore/add/remove/force
+sp_catch_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space before the '{' of a '@catch' statement, if the '{'
 # and '@catch' are on the same line, as in '@catch (decl) <here> {'.
 # If set to ignore, sp_catch_brace is used.
-sp_oc_catch_brace               = ignore   # ignore/add/remove/force
+sp_oc_catch_brace               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '}' and 'catch' if on the same line.
-sp_brace_catch                  = ignore   # ignore/add/remove/force
+sp_brace_catch                  = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space between '}' and '@catch' if on the same line.
 # If set to ignore, sp_brace_catch is used.
-sp_oc_brace_catch               = ignore   # ignore/add/remove/force
+sp_oc_brace_catch               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'finally' and '{' if on the same line.
-sp_finally_brace                = ignore   # ignore/add/remove/force
+sp_finally_brace                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '}' and 'finally' if on the same line.
-sp_brace_finally                = ignore   # ignore/add/remove/force
+sp_brace_finally                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'try' and '{' if on the same line.
-sp_try_brace                    = ignore   # ignore/add/remove/force
+sp_try_brace                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between get/set and '{' if on the same line.
-sp_getset_brace                 = ignore   # ignore/add/remove/force
+sp_getset_brace                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a variable and '{' for C++ uniform
 # initialization.
-sp_word_brace_init_lst          = ignore   # ignore/add/remove/force
+sp_word_brace_init_lst          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between a variable and '{' for a namespace.
 #
 # Default: add
-sp_word_brace_ns                = add      # ignore/add/remove/force
+sp_word_brace_ns                = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space before the '::' operator.
-sp_before_dc                    = ignore   # ignore/add/remove/force
+sp_before_dc                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '::' operator.
-sp_after_dc                     = ignore   # ignore/add/remove/force
+sp_after_dc                     = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove around the D named array initializer ':' operator.
-sp_d_array_colon                = ignore   # ignore/add/remove/force
+sp_d_array_colon                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '!' (not) unary operator.
 #
 # Default: remove
-sp_not                          = remove   # ignore/add/remove/force
+sp_not                          = remove   # ignore/add/remove/force/not_defined
+
+# Add or remove space between two '!' (not) unary operators.
+# If set to ignore, sp_not will be used.
+sp_not_not                      = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '~' (invert) unary operator.
 #
 # Default: remove
-sp_inv                          = remove   # ignore/add/remove/force
+sp_inv                          = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '&' (address-of) unary operator. This does not
 # affect the spacing after a '&' that is part of a type.
 #
 # Default: remove
-sp_addr                         = remove   # ignore/add/remove/force
+sp_addr                         = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space around the '.' or '->' operators.
 #
 # Default: remove
-sp_member                       = remove   # ignore/add/remove/force
+sp_member                       = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '*' (dereference) unary operator. This does
 # not affect the spacing after a '*' that is part of a type.
 #
 # Default: remove
-sp_deref                        = remove   # ignore/add/remove/force
+sp_deref                        = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'.
 #
 # Default: remove
-sp_sign                         = remove   # ignore/add/remove/force
+sp_sign                         = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '++' and '--' the word to which it is being
 # applied, as in '(--x)' or 'y++;'.
 #
 # Default: remove
-sp_incdec                       = remove   # ignore/add/remove/force
+sp_incdec                       = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space before a backslash-newline at the end of a line.
 #
 # Default: add
-sp_before_nl_cont               = add      # ignore/add/remove/force
+sp_before_nl_cont               = add      # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after the scope '+' or '-', as in '-(void) foo;'
 # or '+(int) bar;'.
-sp_after_oc_scope               = ignore   # ignore/add/remove/force
+sp_after_oc_scope               = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after the colon in message specs,
 # i.e. '-(int) f:(int) x;' vs. '-(int) f: (int) x;'.
-sp_after_oc_colon               = ignore   # ignore/add/remove/force
+sp_after_oc_colon               = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space before the colon in message specs,
 # i.e. '-(int) f: (int) x;' vs. '-(int) f : (int) x;'.
-sp_before_oc_colon              = ignore   # ignore/add/remove/force
+sp_before_oc_colon              = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after the colon in immutable dictionary expression
 # 'NSDictionary *test = @{@"foo" :@"bar"};'.
-sp_after_oc_dict_colon          = ignore   # ignore/add/remove/force
+sp_after_oc_dict_colon          = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space before the colon in immutable dictionary expression
 # 'NSDictionary *test = @{@"foo" :@"bar"};'.
-sp_before_oc_dict_colon         = ignore   # ignore/add/remove/force
+sp_before_oc_dict_colon         = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after the colon in message specs,
 # i.e. '[object setValue:1];' vs. '[object setValue: 1];'.
-sp_after_send_oc_colon          = ignore   # ignore/add/remove/force
+sp_after_send_oc_colon          = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space before the colon in message specs,
 # i.e. '[object setValue:1];' vs. '[object setValue :1];'.
-sp_before_send_oc_colon         = ignore   # ignore/add/remove/force
+sp_before_send_oc_colon         = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after the (type) in message specs,
 # i.e. '-(int)f: (int) x;' vs. '-(int)f: (int)x;'.
-sp_after_oc_type                = ignore   # ignore/add/remove/force
+sp_after_oc_type                = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after the first (type) in message specs,
 # i.e. '-(int) f:(int)x;' vs. '-(int)f:(int)x;'.
-sp_after_oc_return_type         = ignore   # ignore/add/remove/force
+sp_after_oc_return_type         = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space between '@selector' and '(',
 # i.e. '@selector(msgName)' vs. '@selector (msgName)'.
 # Also applies to '@protocol()' constructs.
-sp_after_oc_at_sel              = ignore   # ignore/add/remove/force
+sp_after_oc_at_sel              = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space between '@selector(x)' and the following word,
 # i.e. '@selector(foo) a:' vs. '@selector(foo)a:'.
-sp_after_oc_at_sel_parens       = ignore   # ignore/add/remove/force
+sp_after_oc_at_sel_parens       = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space inside '@selector' parentheses,
 # i.e. '@selector(foo)' vs. '@selector( foo )'.
 # Also applies to '@protocol()' constructs.
-sp_inside_oc_at_sel_parens      = ignore   # ignore/add/remove/force
+sp_inside_oc_at_sel_parens      = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space before a block pointer caret,
 # i.e. '^int (int arg){...}' vs. ' ^int (int arg){...}'.
-sp_before_oc_block_caret        = ignore   # ignore/add/remove/force
+sp_before_oc_block_caret        = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after a block pointer caret,
 # i.e. '^int (int arg){...}' vs. '^ int (int arg){...}'.
-sp_after_oc_block_caret         = ignore   # ignore/add/remove/force
+sp_after_oc_block_caret         = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space between the receiver and selector in a message,
 # as in '[receiver selector ...]'.
-sp_after_oc_msg_receiver        = ignore   # ignore/add/remove/force
+sp_after_oc_msg_receiver        = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space after '@property'.
-sp_after_oc_property            = ignore   # ignore/add/remove/force
+sp_after_oc_property            = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space between '@synchronized' and the open parenthesis,
 # i.e. '@synchronized(foo)' vs. '@synchronized (foo)'.
-sp_after_oc_synchronized        = ignore   # ignore/add/remove/force
+sp_after_oc_synchronized        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around the ':' in 'b ? t : f'.
-sp_cond_colon                   = ignore   # ignore/add/remove/force
+sp_cond_colon                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before the ':' in 'b ? t : f'.
 #
 # Overrides sp_cond_colon.
-sp_cond_colon_before            = ignore   # ignore/add/remove/force
+sp_cond_colon_before            = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the ':' in 'b ? t : f'.
 #
 # Overrides sp_cond_colon.
-sp_cond_colon_after             = ignore   # ignore/add/remove/force
+sp_cond_colon_after             = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around the '?' in 'b ? t : f'.
-sp_cond_question                = ignore   # ignore/add/remove/force
+sp_cond_question                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before the '?' in 'b ? t : f'.
 #
 # Overrides sp_cond_question.
-sp_cond_question_before         = ignore   # ignore/add/remove/force
+sp_cond_question_before         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '?' in 'b ? t : f'.
 #
 # Overrides sp_cond_question.
-sp_cond_question_after          = ignore   # ignore/add/remove/force
+sp_cond_question_after          = ignore   # ignore/add/remove/force/not_defined
 
 # In the abbreviated ternary form '(a ?: b)', add or remove space between '?'
 # and ':'.
 #
 # Overrides all other sp_cond_* options.
-sp_cond_ternary_short           = ignore   # ignore/add/remove/force
+sp_cond_ternary_short           = ignore   # ignore/add/remove/force/not_defined
 
 # Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make
 # sense here.
-sp_case_label                   = ignore   # ignore/add/remove/force
+sp_case_label                   = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove space around the D '..' operator.
-sp_range                        = ignore   # ignore/add/remove/force
+sp_range                        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after ':' in a Java/C++11 range-based 'for',
-# as in 'for (Type var : expr)'.
-sp_after_for_colon              = ignore   # ignore/add/remove/force
+# as in 'for (Type var : <here> expr)'.
+sp_after_for_colon              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before ':' in a Java/C++11 range-based 'for',
-# as in 'for (Type var : expr)'.
-sp_before_for_colon             = ignore   # ignore/add/remove/force
+# as in 'for (Type var <here> : expr)'.
+sp_before_for_colon             = ignore   # ignore/add/remove/force/not_defined
 
-# (D) Add or remove space between 'extern' and '(' as in 'extern (C)'.
-sp_extern_paren                 = ignore   # ignore/add/remove/force
+# (D) Add or remove space between 'extern' and '(' as in 'extern <here> (C)'.
+sp_extern_paren                 = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space after the opening of a C++ comment,
-# i.e. '// A' vs. '//A'.
-sp_cmt_cpp_start                = ignore   # ignore/add/remove/force
+# Add or remove space after the opening of a C++ comment, as in '// <here> A'.
+sp_cmt_cpp_start                = ignore   # ignore/add/remove/force/not_defined
 
-# If true, space is added with sp_cmt_cpp_start will be added after doxygen
+# remove space after the '//' and the pvs command '-V1234',
+# only works with sp_cmt_cpp_start set to add or force.
+sp_cmt_cpp_pvs                  = false    # true/false
+
+# remove space after the '//' and the command 'lint',
+# only works with sp_cmt_cpp_start set to add or force.
+sp_cmt_cpp_lint                 = false    # true/false
+
+# Add or remove space in a C++ region marker comment, as in '// <here> BEGIN'.
+# A region marker is defined as a comment which is not preceded by other text
+# (i.e. the comment is the first non-whitespace on the line), and which starts
+# with either 'BEGIN' or 'END'.
+#
+# Overrides sp_cmt_cpp_start.
+sp_cmt_cpp_region               = ignore   # ignore/add/remove/force/not_defined
+
+# If true, space added with sp_cmt_cpp_start will be added after Doxygen
 # sequences like '///', '///<', '//!' and '//!<'.
 sp_cmt_cpp_doxygen              = false    # true/false
 
-# If true, space is added with sp_cmt_cpp_start will be added after Qt
-# translator or meta-data comments like '//:', '//=', and '//~'.
+# If true, space added with sp_cmt_cpp_start will be added after Qt translator
+# or meta-data comments like '//:', '//=', and '//~'.
 sp_cmt_cpp_qttr                 = false    # true/false
 
 # Add or remove space between #else or #endif and a trailing comment.
-sp_endif_cmt                    = ignore   # ignore/add/remove/force
+sp_endif_cmt                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after 'new', 'delete' and 'delete[]'.
-sp_after_new                    = ignore   # ignore/add/remove/force
+sp_after_new                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'new' and '(' in 'new()'.
-sp_between_new_paren            = ignore   # ignore/add/remove/force
+sp_between_new_paren            = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between ')' and type in 'new(foo) BAR'.
-sp_after_newop_paren            = ignore   # ignore/add/remove/force
+sp_after_newop_paren            = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space inside parenthesis of the new operator
+# Add or remove space inside parentheses of the new operator
 # as in 'new(foo) BAR'.
-sp_inside_newop_paren           = ignore   # ignore/add/remove/force
+sp_inside_newop_paren           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the open parenthesis of the new operator,
 # as in 'new(foo) BAR'.
 #
 # Overrides sp_inside_newop_paren.
-sp_inside_newop_paren_open      = ignore   # ignore/add/remove/force
+sp_inside_newop_paren_open      = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before the close parenthesis of the new operator,
 # as in 'new(foo) BAR'.
 #
 # Overrides sp_inside_newop_paren.
-sp_inside_newop_paren_close     = ignore   # ignore/add/remove/force
+sp_inside_newop_paren_close     = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space before a trailing or embedded comment.
-sp_before_tr_cmt                = ignore   # ignore/add/remove/force
+# Add or remove space before a trailing comment.
+sp_before_tr_cmt                = ignore   # ignore/add/remove/force/not_defined
 
-# Number of spaces before a trailing or embedded comment.
+# Number of spaces before a trailing comment.
 sp_num_before_tr_cmt            = 0        # unsigned number
 
+# Add or remove space before an embedded comment.
+#
+# Default: force
+sp_before_emb_cmt               = force    # ignore/add/remove/force/not_defined
+
+# Number of spaces before an embedded comment.
+#
+# Default: 1
+sp_num_before_emb_cmt           = 1        # unsigned number
+
+# Add or remove space after an embedded comment.
+#
+# Default: force
+sp_after_emb_cmt                = force    # ignore/add/remove/force/not_defined
+
+# Number of spaces after an embedded comment.
+#
+# Default: 1
+sp_num_after_emb_cmt            = 1        # unsigned number
+
 # (Java) Add or remove space between an annotation and the open parenthesis.
-sp_annotation_paren             = ignore   # ignore/add/remove/force
+sp_annotation_paren             = ignore   # ignore/add/remove/force/not_defined
 
 # If true, vbrace tokens are dropped to the previous token and skipped.
 sp_skip_vbrace_tokens           = false    # true/false
 
 # Add or remove space after 'noexcept'.
-sp_after_noexcept               = ignore   # ignore/add/remove/force
+sp_after_noexcept               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after '_'.
-sp_vala_after_translation       = ignore   # ignore/add/remove/force
+sp_vala_after_translation       = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space before a bit colon ':'.
+sp_before_bit_colon             = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after a bit colon ':'.
+sp_after_bit_colon              = ignore   # ignore/add/remove/force/not_defined
 
 # If true, a <TAB> is inserted after #define.
 force_tab_after_define          = false    # true/false
@@ -926,17 +1130,23 @@ force_tab_after_define          = false    # true/false
 # The number of columns to indent per level. Usually 2, 3, 4, or 8.
 #
 # Default: 8
-indent_columns                  = output_tab_size        # unsigned number
+indent_columns                  = 4        # unsigned number
+
+# Whether to ignore indent for the first continuation line. Subsequent
+# continuation lines will still be indented to match the first.
+indent_ignore_first_continue    = false    # true/false
 
 # The continuation indent. If non-zero, this overrides the indent of '(', '['
 # and '=' continuation indents. Negative values are OK; negative value is
 # absolute and not increased for each '(' or '[' level.
 #
 # For FreeBSD, this is set to 4.
+# Requires indent_ignore_first_continue=false.
 indent_continue                 = 8        # number
 
 # The continuation indent, only for class header line(s). If non-zero, this
 # overrides the indent of 'class' continuation indents.
+# Requires indent_ignore_first_continue=false.
 indent_continue_class_head      = 0        # unsigned number
 
 # Whether to indent empty lines (i.e. lines which contain only spaces before
@@ -1012,11 +1222,24 @@ indent_namespace_level          = 0        # unsigned number
 # indented. Requires indent_namespace=true. 0 means no limit.
 indent_namespace_limit          = 0        # unsigned number
 
+# Whether to indent only in inner namespaces (nested in other namespaces).
+# Requires indent_namespace=true.
+indent_namespace_inner_only     = false    # true/false
+
 # Whether the 'extern "C"' body is indented.
 indent_extern                   = false    # true/false
 
 # Whether the 'class' body is indented.
 indent_class                    = true     # true/false
+
+# Whether to ignore indent for the leading base class colon.
+indent_ignore_before_class_colon = false    # true/false
+
+# Additional indent before the leading base class colon.
+# Negative values decrease indent down to the first column.
+# Requires indent_ignore_before_class_colon=false and a newline break before
+# the colon (see pos_class_colon and nl_class_colon)
+indent_before_class_colon       = 0        # number
 
 # Whether to indent the stuff after a leading base class colon.
 indent_class_colon              = false    # true/false
@@ -1025,13 +1248,21 @@ indent_class_colon              = false    # true/false
 # colon. Requires indent_class_colon=true.
 indent_class_on_colon           = false    # true/false
 
+# Whether to ignore indent for a leading class initializer colon.
+indent_ignore_before_constr_colon = false    # true/false
+
 # Whether to indent the stuff after a leading class initializer colon.
 indent_constr_colon             = false    # true/false
 
-# Virtual indent from the ':' for member initializers.
+# Virtual indent from the ':' for leading member initializers.
 #
 # Default: 2
 indent_ctor_init_leading        = 2        # unsigned number
+
+# Virtual indent from the ':' for following member initializers.
+#
+# Default: 2
+indent_ctor_init_following      = 2        # unsigned number
 
 # Additional indent for constructor initializer list.
 # Negative values decrease indent down to the first column.
@@ -1050,9 +1281,12 @@ indent_var_def_blk              = 0        # number
 # Whether to indent continued variable declarations instead of aligning.
 indent_var_def_cont             = false    # true/false
 
-# Whether to indent continued shift expressions ('<<' and '>>') instead of
-# aligning. Set align_left_shift=false when enabling this.
-indent_shift                    = 0        # true:1/false:0
+# How to indent continued shift expressions ('<<' and '>>').
+# Set align_left_shift=false when using this.
+#  0: Align shift operators instead of indenting them (default)
+#  1: Indent by one level
+# -1: Preserve original indentation
+indent_shift                    = 0        # number
 
 # Whether to force indentation of function definitions to start in column 1.
 indent_func_def_force_col1      = false    # true/false
@@ -1111,7 +1345,7 @@ indent_macro_brace              = true     # true/false
 
 # The number of spaces to indent a continued '->' or '.'.
 # Usually set to 0, 1, or indent_columns.
-indent_member                   = indent_continue        # unsigned number
+indent_member                   = 8        # unsigned number
 
 # Whether lines broken at '.' or '->' should be indented by a single indent.
 # The indent_member option will not be effective if this is set to true.
@@ -1119,6 +1353,9 @@ indent_member_single            = false    # true/false
 
 # Spaces to indent single line ('//') comments on lines before code.
 indent_single_line_comments_before = 0        # unsigned number
+
+# Spaces to indent single line ('//') comments on lines after code.
+indent_single_line_comments_after = 0        # unsigned number
 
 # When opening a paren for a control statement (if, for, while, etc), increase
 # the indent level by this value. Negative values decrease the indent level.
@@ -1129,7 +1366,20 @@ indent_sparen_extra             = 0        # number
 indent_relative_single_line_comments = false    # true/false
 
 # Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.
-indent_switch_case              = indent_columns        # unsigned number
+# It might be wise to choose the same value for the option indent_case_brace.
+indent_switch_case              = 4        # unsigned number
+
+# Spaces to indent the body of a 'switch' before any 'case'.
+# Usually the same as indent_columns or indent_switch_case.
+indent_switch_body              = 0        # unsigned number
+
+# Whether to ignore indent for '{' following 'case'.
+indent_ignore_case_brace        = false    # true/false
+
+# Spaces to indent '{' from 'case'. By default, the brace will appear under
+# the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.
+# It might be wise to choose the same value for the option indent_switch_case.
+indent_case_brace               = 0        # number
 
 # indent 'break' with 'case' from 'switch'.
 indent_switch_break_with_case   = false    # true/false
@@ -1143,9 +1393,15 @@ indent_switch_pp                = true     # true/false
 # Usually 0.
 indent_case_shift               = 0        # unsigned number
 
-# Spaces to indent '{' from 'case'. By default, the brace will appear under
-# the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.
-indent_case_brace               = 0        # number
+# Whether to align comments before 'case' with the 'case'.
+#
+# Default: true
+indent_case_comment             = true     # true/false
+
+# Whether to indent comments not found in first column.
+#
+# Default: true
+indent_comment                  = true     # true/false
 
 # Whether to indent comments found in first column.
 indent_col1_comment             = true     # true/false
@@ -1153,7 +1409,15 @@ indent_col1_comment             = true     # true/false
 # Whether to indent multi string literal in first column.
 indent_col1_multi_string_literal = false    # true/false
 
-# How to indent goto labels.
+# Align comments on adjacent lines that are this many columns apart or less.
+#
+# Default: 3
+indent_comment_align_thresh     = 3        # unsigned number
+
+# Whether to ignore indent for goto labels.
+indent_ignore_label             = false    # true/false
+
+# How to indent goto labels. Requires indent_ignore_label=false.
 #
 #  >0: Absolute column where 1 is the leftmost column
 # <=0: Subtract from brace indent
@@ -1168,7 +1432,7 @@ indent_label                    = 1        # number
 # <=0: Subtract from brace indent
 #
 # Default: 1
-indent_access_spec              = -4        # number
+indent_access_spec              = -4       # number
 
 # Whether to indent the code after an access specifier by one level.
 # If true, this option forces 'indent_access_spec=0'.
@@ -1180,10 +1444,11 @@ indent_paren_nl                 = false    # true/false
 
 # How to indent a close parenthesis after a newline.
 #
-# 0: Indent to body level (default)
-# 1: Align under the open parenthesis
-# 2: Indent to the brace level
-indent_paren_close              = 0        # unsigned number
+#  0: Indent to body level (default)
+#  1: Align under the open parenthesis
+#  2: Indent to the brace level
+# -1: Preserve original indentation
+indent_paren_close              = 0        # number
 
 # Whether to indent the open parenthesis of a function definition,
 # if the parenthesis is on its own line.
@@ -1197,20 +1462,41 @@ indent_paren_after_func_decl    = false    # true/false
 # if the parenthesis is on its own line.
 indent_paren_after_func_call    = false    # true/false
 
-# Whether to indent a comma when inside a parenthesis.
-# If true, aligns under the open parenthesis.
-indent_comma_paren              = 0        # true:1/false:0
+# How to indent a comma when inside braces.
+#  0: Indent by one level (default)
+#  1: Align under the open brace
+# -1: Preserve original indentation
+indent_comma_brace              = 0        # number
 
-# Whether to indent a Boolean operator when inside a parenthesis.
-# If true, aligns under the open parenthesis.
-indent_bool_paren               = 0        # true:1/false:0
+# How to indent a comma when inside parentheses.
+#  0: Indent by one level (default)
+#  1: Align under the open parenthesis
+# -1: Preserve original indentation
+indent_comma_paren              = 0        # number
+
+# How to indent a Boolean operator when inside parentheses.
+#  0: Indent by one level (default)
+#  1: Align under the open parenthesis
+# -1: Preserve original indentation
+indent_bool_paren               = 0        # number
+
+# Whether to ignore the indentation of a Boolean operator when outside
+# parentheses.
+indent_ignore_bool              = false    # true/false
+
+# Whether to ignore the indentation of an arithmetic operator.
+indent_ignore_arith             = false    # true/false
 
 # Whether to indent a semicolon when inside a for parenthesis.
 # If true, aligns under the open for parenthesis.
 indent_semicolon_for_paren      = false    # true/false
 
+# Whether to ignore the indentation of a semicolon outside of a 'for'
+# statement.
+indent_ignore_semicolon         = false    # true/false
+
 # Whether to align the first expression to following ones
-# if indent_bool_paren=true.
+# if indent_bool_paren=1.
 indent_first_bool_expr          = false    # true/false
 
 # Whether to align the first expression to following ones
@@ -1223,6 +1509,9 @@ indent_square_nl                = false    # true/false
 
 # (ESQL/C) Whether to preserve the relative indent of 'EXEC SQL' bodies.
 indent_preserve_sql             = false    # true/false
+
+# Whether to ignore the indentation of an assignment operator.
+indent_ignore_assign            = false    # true/false
 
 # Whether to align continued statements at the '='. If false or if the '=' is
 # followed by a newline, the next line is indent one tab.
@@ -1289,7 +1578,7 @@ indent_oc_block_msg_from_brace  = false    # true/false
 indent_min_vbrace_open          = 0        # unsigned number
 
 # Whether to add further spaces after regular indent to reach next tabstop
-# when identing after virtual brace open and newline.
+# when indenting after virtual brace open and newline.
 indent_vbrace_open_on_tabstop   = false    # true/false
 
 # How to indent after a brace followed by another token (not a newline).
@@ -1300,13 +1589,13 @@ indent_vbrace_open_on_tabstop   = false    # true/false
 indent_token_after_brace        = true     # true/false
 
 # Whether to indent the body of a C++11 lambda.
-indent_cpp_lambda_body          = true    # true/false
+indent_cpp_lambda_body          = true     # true/false
 
 # How to indent compound literals that are being returned.
-# true: add both the indent from return & the compound literal open brace (ie:
-#       2 indent levels)
-# false: only indent 1 level, don't add the indent for the open brace, only add
-#        the indent for the return.
+# true: add both the indent from return & the compound literal open brace
+#       (i.e. 2 indent levels)
+# false: only indent 1 level, don't add the indent for the open brace, only
+#        add the indent for the return.
 #
 # Default: true
 indent_compound_literal_return  = true     # true/false
@@ -1319,11 +1608,11 @@ indent_using_block              = true     # true/false
 # How to indent the continuation of ternary operator.
 #
 # 0: Off (default)
-# 1: When the `if_false` is a continuation, indent it under `if_false`
+# 1: When the `if_false` is a continuation, indent it under the `if_true` branch
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 
-# Whether to indent the statments inside ternary operator.
+# Whether to indent the statements inside ternary operator.
 indent_inside_ternary_operator  = false    # true/false
 
 # If true, the indentation of the chunks after a `return` sequence will be set at return indentation column.
@@ -1339,12 +1628,22 @@ indent_single_after_return      = false    # true/false
 # have their own indentation).
 indent_ignore_asm_block         = false    # true/false
 
+# Don't indent the close parenthesis of a function definition,
+# if the parenthesis is on its own line.
+donot_indent_func_def_close_paren = false    # true/false
+
 #
 # Newline adding and removing options
 #
 
-# Whether to collapse empty blocks between '{' and '}'.
+# Whether to collapse empty blocks between '{' and '}' except for functions.
+# Use nl_collapse_empty_body_functions to specify how empty function braces
+# should be formatted.
 nl_collapse_empty_body          = false    # true/false
+
+# Whether to collapse empty blocks between '{' and '}' for functions only.
+# If true, overrides nl_inside_empty_func.
+nl_collapse_empty_body_functions = false    # true/false
 
 # Don't split one-line braced assignments, as in 'foo_t f = { 1, 2 };'.
 nl_assign_leave_one_liners      = false    # true/false
@@ -1374,6 +1673,9 @@ nl_if_leave_one_liners          = false    # true/false
 # Don't split one-line while statements, as in 'while(...) b++;'.
 nl_while_leave_one_liners       = false    # true/false
 
+# Don't split one-line do statements, as in 'do { b++; } while(...);'.
+nl_do_leave_one_liners          = false    # true/false
+
 # Don't split one-line for statements, as in 'for(...) b++;'.
 nl_for_leave_one_liners         = false    # true/false
 
@@ -1381,166 +1683,166 @@ nl_for_leave_one_liners         = false    # true/false
 nl_oc_msg_leave_one_liner       = false    # true/false
 
 # (OC) Add or remove newline between method declaration and '{'.
-nl_oc_mdef_brace                = ignore   # ignore/add/remove/force
+nl_oc_mdef_brace                = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove newline between Objective-C block signature and '{'.
-nl_oc_block_brace               = ignore   # ignore/add/remove/force
+nl_oc_block_brace               = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove blank line before '@interface' statement.
-nl_oc_before_interface          = ignore   # ignore/add/remove/force
+nl_oc_before_interface          = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove blank line before '@implementation' statement.
-nl_oc_before_implementation     = ignore   # ignore/add/remove/force
+nl_oc_before_implementation     = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove blank line before '@end' statement.
-nl_oc_before_end                = ignore   # ignore/add/remove/force
+nl_oc_before_end                = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove newline between '@interface' and '{'.
-nl_oc_interface_brace           = ignore   # ignore/add/remove/force
+nl_oc_interface_brace           = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove newline between '@implementation' and '{'.
-nl_oc_implementation_brace      = ignore   # ignore/add/remove/force
+nl_oc_implementation_brace      = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newlines at the start of the file.
-nl_start_of_file                = ignore   # ignore/add/remove/force
+nl_start_of_file                = ignore   # ignore/add/remove/force/not_defined
 
 # The minimum number of newlines at the start of the file (only used if
 # nl_start_of_file is 'add' or 'force').
 nl_start_of_file_min            = 0        # unsigned number
 
 # Add or remove newline at the end of the file.
-nl_end_of_file                  = ignore   # ignore/add/remove/force
+nl_end_of_file                  = ignore   # ignore/add/remove/force/not_defined
 
 # The minimum number of newlines at the end of the file (only used if
 # nl_end_of_file is 'add' or 'force').
 nl_end_of_file_min              = 0        # unsigned number
 
 # Add or remove newline between '=' and '{'.
-nl_assign_brace                 = ignore   # ignore/add/remove/force
+nl_assign_brace                 = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove newline between '=' and '['.
-nl_assign_square                = ignore   # ignore/add/remove/force
+nl_assign_square                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '[]' and '{'.
-nl_tsquare_brace                = ignore   # ignore/add/remove/force
+nl_tsquare_brace                = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove newline after '= ['. Will also affect the newline before
 # the ']'.
-nl_after_square_assign          = ignore   # ignore/add/remove/force
+nl_after_square_assign          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between a function call's ')' and '{', as in
 # 'list_for_each(item, &list) { }'.
-nl_fcall_brace                  = ignore   # ignore/add/remove/force
+nl_fcall_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'enum' and '{'.
-nl_enum_brace                   = add      # ignore/add/remove/force
+nl_enum_brace                   = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'enum' and 'class'.
-nl_enum_class                   = ignore   # ignore/add/remove/force
+nl_enum_class                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'enum class' and the identifier.
-nl_enum_class_identifier        = ignore   # ignore/add/remove/force
+nl_enum_class_identifier        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'enum class' type and ':'.
-nl_enum_identifier_colon        = ignore   # ignore/add/remove/force
+nl_enum_identifier_colon        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'enum class identifier :' and type.
-nl_enum_colon_type              = ignore   # ignore/add/remove/force
+nl_enum_colon_type              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'struct and '{'.
-nl_struct_brace                 = add      # ignore/add/remove/force
+nl_struct_brace                 = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'union' and '{'.
-nl_union_brace                  = add      # ignore/add/remove/force
+nl_union_brace                  = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'if' and '{'.
-nl_if_brace                     = add      # ignore/add/remove/force
+nl_if_brace                     = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '}' and 'else'.
-nl_brace_else                   = add      # ignore/add/remove/force
+nl_brace_else                   = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'else if' and '{'. If set to ignore,
 # nl_if_brace is used instead.
-nl_elseif_brace                 = add      # ignore/add/remove/force
+nl_elseif_brace                 = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'else' and '{'.
-nl_else_brace                   = add      # ignore/add/remove/force
+nl_else_brace                   = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'else' and 'if'.
-nl_else_if                      = remove   # ignore/add/remove/force
+nl_else_if                      = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline before '{' opening brace
-nl_before_opening_brace_func_class_def = ignore   # ignore/add/remove/force
+nl_before_opening_brace_func_class_def = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline before 'if'/'else if' closing parenthesis.
-nl_before_if_closing_paren      = ignore   # ignore/add/remove/force
+nl_before_if_closing_paren      = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '}' and 'finally'.
-nl_brace_finally                = ignore   # ignore/add/remove/force
+nl_brace_finally                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'finally' and '{'.
-nl_finally_brace                = ignore   # ignore/add/remove/force
+nl_finally_brace                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'try' and '{'.
-nl_try_brace                    = add   # ignore/add/remove/force
+nl_try_brace                    = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline between get/set and '{'.
-nl_getset_brace                 = ignore   # ignore/add/remove/force
+nl_getset_brace                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'for' and '{'.
-nl_for_brace                    = add      # ignore/add/remove/force
+nl_for_brace                    = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline before the '{' of a 'catch' statement, as in
 # 'catch (decl) <here> {'.
-nl_catch_brace                  = add   # ignore/add/remove/force
+nl_catch_brace                  = add      # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove newline before the '{' of a '@catch' statement, as in
 # '@catch (decl) <here> {'. If set to ignore, nl_catch_brace is used.
-nl_oc_catch_brace               = ignore   # ignore/add/remove/force
+nl_oc_catch_brace               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '}' and 'catch'.
-nl_brace_catch                  = ignore   # ignore/add/remove/force
+nl_brace_catch                  = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove newline between '}' and '@catch'. If set to ignore,
 # nl_brace_catch is used.
-nl_oc_brace_catch               = ignore   # ignore/add/remove/force
+nl_oc_brace_catch               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '}' and ']'.
-nl_brace_square                 = ignore   # ignore/add/remove/force
+nl_brace_square                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '}' and ')' in a function invocation.
-nl_brace_fparen                 = ignore   # ignore/add/remove/force
+nl_brace_fparen                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'while' and '{'.
-nl_while_brace                  = add      # ignore/add/remove/force
+nl_while_brace                  = add      # ignore/add/remove/force/not_defined
 
 # (D) Add or remove newline between 'scope (x)' and '{'.
-nl_scope_brace                  = ignore   # ignore/add/remove/force
+nl_scope_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove newline between 'unittest' and '{'.
-nl_unittest_brace               = ignore   # ignore/add/remove/force
+nl_unittest_brace               = ignore   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove newline between 'version (x)' and '{'.
-nl_version_brace                = ignore   # ignore/add/remove/force
+nl_version_brace                = ignore   # ignore/add/remove/force/not_defined
 
 # (C#) Add or remove newline between 'using' and '{'.
-nl_using_brace                  = ignore   # ignore/add/remove/force
+nl_using_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between two open or close braces. Due to general
 # newline/brace handling, REMOVE may not work.
-nl_brace_brace                  = ignore   # ignore/add/remove/force
+nl_brace_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'do' and '{'.
-nl_do_brace                     = ignore   # ignore/add/remove/force
+nl_do_brace                     = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '}' and 'while' of 'do' statement.
-nl_brace_while                  = ignore   # ignore/add/remove/force
+nl_brace_while                  = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'switch' and '{'.
-nl_switch_brace                 = ignore   # ignore/add/remove/force
+nl_switch_brace                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'synchronized' and '{'.
-nl_synchronized_brace           = ignore   # ignore/add/remove/force
+nl_synchronized_brace           = ignore   # ignore/add/remove/force/not_defined
 
 # Add a newline between ')' and '{' if the ')' is on a different line than the
 # if/for/etc.
@@ -1551,11 +1853,11 @@ nl_multi_line_cond              = false    # true/false
 
 # Add a newline after '(' if an if/for/while/switch condition spans multiple
 # lines
-nl_multi_line_sparen_open       = ignore   # ignore/add/remove/force
+nl_multi_line_sparen_open       = ignore   # ignore/add/remove/force/not_defined
 
 # Add a newline before ')' if an if/for/while/switch condition spans multiple
 # lines. Overrides nl_before_if_closing_paren if both are specified.
-nl_multi_line_sparen_close      = ignore   # ignore/add/remove/force
+nl_multi_line_sparen_close      = ignore   # ignore/add/remove/force/not_defined
 
 # Force a newline in a define after the macro name for multi-line defines.
 nl_multi_line_define            = false    # true/false
@@ -1570,141 +1872,141 @@ nl_after_case                   = false    # true/false
 # Add or remove newline between a case ':' and '{'.
 #
 # Overrides nl_after_case.
-nl_case_colon_brace             = ignore   # ignore/add/remove/force
+nl_case_colon_brace             = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between ')' and 'throw'.
-nl_before_throw                 = ignore   # ignore/add/remove/force
+nl_before_throw                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'namespace' and '{'.
-nl_namespace_brace              = remove   # ignore/add/remove/force
+nl_namespace_brace              = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after 'template<...>' of a template class.
-nl_template_class               = ignore   # ignore/add/remove/force
+nl_template_class               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after 'template<...>' of a template class declaration.
 #
 # Overrides nl_template_class.
-nl_template_class_decl          = ignore   # ignore/add/remove/force
+nl_template_class_decl          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after 'template<>' of a specialized class declaration.
 #
 # Overrides nl_template_class_decl.
-nl_template_class_decl_special  = ignore   # ignore/add/remove/force
+nl_template_class_decl_special  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after 'template<...>' of a template class definition.
 #
 # Overrides nl_template_class.
-nl_template_class_def           = ignore   # ignore/add/remove/force
+nl_template_class_def           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after 'template<>' of a specialized class definition.
 #
 # Overrides nl_template_class_def.
-nl_template_class_def_special   = ignore   # ignore/add/remove/force
+nl_template_class_def_special   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after 'template<...>' of a template function.
-nl_template_func                = ignore   # ignore/add/remove/force
+nl_template_func                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after 'template<...>' of a template function
 # declaration.
 #
 # Overrides nl_template_func.
-nl_template_func_decl           = ignore   # ignore/add/remove/force
+nl_template_func_decl           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after 'template<>' of a specialized function
 # declaration.
 #
 # Overrides nl_template_func_decl.
-nl_template_func_decl_special   = ignore   # ignore/add/remove/force
+nl_template_func_decl_special   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after 'template<...>' of a template function
 # definition.
 #
 # Overrides nl_template_func.
-nl_template_func_def            = ignore   # ignore/add/remove/force
+nl_template_func_def            = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after 'template<>' of a specialized function
 # definition.
 #
 # Overrides nl_template_func_def.
-nl_template_func_def_special    = ignore   # ignore/add/remove/force
+nl_template_func_def_special    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after 'template<...>' of a template variable.
-nl_template_var                 = ignore   # ignore/add/remove/force
+nl_template_var                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'template<...>' and 'using' of a templated
 # type alias.
-nl_template_using               = ignore   # ignore/add/remove/force
+nl_template_using               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'class' and '{'.
-nl_class_brace                  = add      # ignore/add/remove/force
+nl_class_brace                  = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline before or after (depending on pos_class_comma,
 # may not be IGNORE) each',' in the base class list.
-nl_class_init_args              = ignore   # ignore/add/remove/force
+nl_class_init_args              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after each ',' in the constructor member
 # initialization. Related to nl_constr_colon, pos_constr_colon and
 # pos_constr_comma.
-nl_constr_init_args             = add      # ignore/add/remove/force
+nl_constr_init_args             = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline before first element, after comma, and after last
 # element, in 'enum'.
-nl_enum_own_lines               = ignore   # ignore/add/remove/force
+nl_enum_own_lines               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between return type and function name in a function
 # definition.
 # might be modified by nl_func_leave_one_liners
-nl_func_type_name               = ignore   # ignore/add/remove/force
+nl_func_type_name               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between return type and function name inside a class
 # definition. If set to ignore, nl_func_type_name or nl_func_proto_type_name
 # is used instead.
-nl_func_type_name_class         = ignore   # ignore/add/remove/force
+nl_func_type_name_class         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between class specification and '::'
 # in 'void A::f() { }'. Only appears in separate member implementation (does
 # not appear with in-line implementation).
-nl_func_class_scope             = ignore   # ignore/add/remove/force
+nl_func_class_scope             = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between function scope and name, as in
 # 'void A :: <here> f() { }'.
-nl_func_scope_name              = ignore   # ignore/add/remove/force
+nl_func_scope_name              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between return type and function name in a prototype.
-nl_func_proto_type_name         = ignore   # ignore/add/remove/force
+nl_func_proto_type_name         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between a function name and the opening '(' in the
 # declaration.
-nl_func_paren                   = ignore   # ignore/add/remove/force
+nl_func_paren                   = ignore   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_paren for functions with no parameters.
-nl_func_paren_empty             = ignore   # ignore/add/remove/force
+nl_func_paren_empty             = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between a function name and the opening '(' in the
 # definition.
-nl_func_def_paren               = ignore   # ignore/add/remove/force
+nl_func_def_paren               = ignore   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_def_paren for functions with no parameters.
-nl_func_def_paren_empty         = ignore   # ignore/add/remove/force
+nl_func_def_paren_empty         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between a function name and the opening '(' in the
 # call.
-nl_func_call_paren              = ignore   # ignore/add/remove/force
+nl_func_call_paren              = ignore   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_call_paren for functions with no parameters.
-nl_func_call_paren_empty        = ignore   # ignore/add/remove/force
+nl_func_call_paren_empty        = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after '(' in a function declaration.
-nl_func_decl_start              = add      # ignore/add/remove/force
+nl_func_decl_start              = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline after '(' in a function definition.
-nl_func_def_start               = add      # ignore/add/remove/force
+nl_func_def_start               = add      # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_decl_start when there is only one parameter.
-nl_func_decl_start_single       = add      # ignore/add/remove/force
+nl_func_decl_start_single       = add      # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_def_start when there is only one parameter.
-nl_func_def_start_single        = add      # ignore/add/remove/force
+nl_func_def_start_single        = add      # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after '(' in a function declaration if '(' and ')'
 # are in different lines. If false, nl_func_decl_start is used instead.
@@ -1715,13 +2017,13 @@ nl_func_decl_start_multi_line   = false    # true/false
 nl_func_def_start_multi_line    = false    # true/false
 
 # Add or remove newline after each ',' in a function declaration.
-nl_func_decl_args               = add      # ignore/add/remove/force
+nl_func_decl_args               = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline after each ',' in a function definition.
-nl_func_def_args                = add      # ignore/add/remove/force
+nl_func_def_args                = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline after each ',' in a function call.
-nl_func_call_args               = ignore   # ignore/add/remove/force
+nl_func_call_args               = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after each ',' in a function declaration if '('
 # and ')' are in different lines. If false, nl_func_decl_args is used instead.
@@ -1732,16 +2034,16 @@ nl_func_decl_args_multi_line    = false    # true/false
 nl_func_def_args_multi_line     = false    # true/false
 
 # Add or remove newline before the ')' in a function declaration.
-nl_func_decl_end                = ignore   # ignore/add/remove/force
+nl_func_decl_end                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline before the ')' in a function definition.
-nl_func_def_end                 = ignore   # ignore/add/remove/force
+nl_func_def_end                 = ignore   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_decl_end when there is only one parameter.
-nl_func_decl_end_single         = ignore   # ignore/add/remove/force
+nl_func_decl_end_single         = ignore   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_def_end when there is only one parameter.
-nl_func_def_end_single          = ignore   # ignore/add/remove/force
+nl_func_def_end_single          = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline before ')' in a function declaration if '(' and ')'
 # are in different lines. If false, nl_func_decl_end is used instead.
@@ -1752,20 +2054,20 @@ nl_func_decl_end_multi_line     = false    # true/false
 nl_func_def_end_multi_line      = false    # true/false
 
 # Add or remove newline between '()' in a function declaration.
-nl_func_decl_empty              = ignore   # ignore/add/remove/force
+nl_func_decl_empty              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '()' in a function definition.
-nl_func_def_empty               = ignore   # ignore/add/remove/force
+nl_func_def_empty               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between '()' in a function call.
-nl_func_call_empty              = ignore   # ignore/add/remove/force
+nl_func_call_empty              = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after '(' in a function call,
 # has preference over nl_func_call_start_multi_line.
-nl_func_call_start              = ignore   # ignore/add/remove/force
+nl_func_call_start              = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline before ')' in a function call.
-nl_func_call_end                = ignore   # ignore/add/remove/force
+nl_func_call_end                = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after '(' in a function call if '(' and ')' are in
 # different lines.
@@ -1779,7 +2081,7 @@ nl_func_call_args_multi_line    = false    # true/false
 # different lines.
 nl_func_call_end_multi_line     = false    # true/false
 
-# Whether to respect nl_func_call_XXX option incase of closure args.
+# Whether to respect nl_func_call_XXX option in case of closure args.
 nl_func_call_args_multi_line_ignore_closures = false    # true/false
 
 # Whether to add a newline after '<' of a template parameter list.
@@ -1795,45 +2097,57 @@ nl_template_end                 = false    # true/false
 # See nl_oc_msg_leave_one_liner.
 nl_oc_msg_args                  = false    # true/false
 
+# (OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.
+nl_oc_msg_args_min_params       = 0        # unsigned number
+
+# (OC) Max code width of Objective-C message before applying nl_oc_msg_args.
+nl_oc_msg_args_max_code_width   = 0        # unsigned number
+
 # Add or remove newline between function signature and '{'.
-nl_fdef_brace                   = add      # ignore/add/remove/force
+nl_fdef_brace                   = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline between function signature and '{',
 # if signature ends with ')'. Overrides nl_fdef_brace.
-nl_fdef_brace_cond              = ignore   # ignore/add/remove/force
+nl_fdef_brace_cond              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between C++11 lambda signature and '{'.
-nl_cpp_ldef_brace               = add   # ignore/add/remove/force
+nl_cpp_ldef_brace               = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'return' and the return expression.
-nl_return_expr                  = ignore   # ignore/add/remove/force
+nl_return_expr                  = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove newline between 'throw' and the throw expression.
+nl_throw_expr                   = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after semicolons, except in 'for' statements.
 nl_after_semicolon              = false    # true/false
 
 # (Java) Add or remove newline between the ')' and '{{' of the double brace
 # initializer.
-nl_paren_dbrace_open            = ignore   # ignore/add/remove/force
+nl_paren_dbrace_open            = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after the type in an unnamed temporary
-# direct-list-initialization.
-nl_type_brace_init_lst          = ignore   # ignore/add/remove/force
+# direct-list-initialization, better:
+# before a direct-list-initialization.
+nl_type_brace_init_lst          = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after the open brace in an unnamed temporary
 # direct-list-initialization.
-nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force
+nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline before the close brace in an unnamed temporary
 # direct-list-initialization.
-nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force
+nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force/not_defined
 
-# Whether to add a newline after '{'. This also adds a newline before the
-# matching '}'.
-nl_after_brace_open             = true    # true/false
+# Whether to add a newline before '{'.
+nl_before_brace_open            = false    # true/false
+
+# Whether to add a newline after '{'.
+nl_after_brace_open             = true     # true/false
 
 # Whether to add a newline between the open brace and a trailing single-line
 # comment. Requires nl_after_brace_open=true.
-nl_after_brace_open_cmt         = true    # true/false
+nl_after_brace_open_cmt         = true     # true/false
 
 # Whether to add a newline after a virtual brace open with a non-empty body.
 # These occur in un-braced if/while/do/for statement bodies.
@@ -1845,7 +2159,7 @@ nl_after_vbrace_open_empty      = false    # true/false
 
 # Whether to add a newline after '}'. Does not apply if followed by a
 # necessary ';'.
-nl_after_brace_close            = true    # true/false
+nl_after_brace_close            = true     # true/false
 
 # Whether to add a newline after a virtual brace close,
 # as in 'if (foo) a++; <here> return;'.
@@ -1854,7 +2168,7 @@ nl_after_vbrace_close           = false    # true/false
 # Add or remove newline between the close brace and identifier,
 # as in 'struct { int a; } <here> b;'. Affects enumerations, unions and
 # structures. If set to ignore, uses nl_after_brace_close.
-nl_brace_struct_var             = ignore   # ignore/add/remove/force
+nl_brace_struct_var             = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to alter newlines in '#define' macros.
 nl_define_macro                 = false    # true/false
@@ -1872,41 +2186,47 @@ nl_squeeze_ifdef                = false    # true/false
 nl_squeeze_ifdef_top_level      = false    # true/false
 
 # Add or remove blank line before 'if'.
-nl_before_if                    = ignore   # ignore/add/remove/force
+nl_before_if                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line after 'if' statement. Add/Force work only if the
 # next token is not a closing brace.
-nl_after_if                     = ignore   # ignore/add/remove/force
+nl_after_if                     = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line before 'for'.
-nl_before_for                   = ignore   # ignore/add/remove/force
+nl_before_for                   = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line after 'for' statement.
-nl_after_for                    = ignore   # ignore/add/remove/force
+nl_after_for                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line before 'while'.
-nl_before_while                 = ignore   # ignore/add/remove/force
+nl_before_while                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line after 'while' statement.
-nl_after_while                  = ignore   # ignore/add/remove/force
+nl_after_while                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line before 'switch'.
-nl_before_switch                = ignore   # ignore/add/remove/force
+nl_before_switch                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line after 'switch' statement.
-nl_after_switch                 = ignore   # ignore/add/remove/force
+nl_after_switch                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line before 'synchronized'.
-nl_before_synchronized          = ignore   # ignore/add/remove/force
+nl_before_synchronized          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line after 'synchronized' statement.
-nl_after_synchronized           = ignore   # ignore/add/remove/force
+nl_after_synchronized           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line before 'do'.
-nl_before_do                    = ignore   # ignore/add/remove/force
+nl_before_do                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line after 'do/while' statement.
-nl_after_do                     = ignore   # ignore/add/remove/force
+nl_after_do                     = ignore   # ignore/add/remove/force/not_defined
+
+# Ignore nl_before_{if,for,switch,do,synchronized} if the control
+# statement is immediately after a case statement.
+# if nl_before_{if,for,switch,do} is set to remove, this option
+# does nothing.
+nl_before_ignore_after_case     = false    # true/false
 
 # Whether to put a blank line before 'return' statements, unless after an open
 # brace.
@@ -1917,10 +2237,10 @@ nl_before_return                = false    # true/false
 nl_after_return                 = false    # true/false
 
 # Whether to put a blank line before a member '.' or '->' operators.
-nl_before_member                = ignore   # ignore/add/remove/force
+nl_before_member                = ignore   # ignore/add/remove/force/not_defined
 
 # (Java) Whether to put a blank line after a member '.' or '->' operators.
-nl_after_member                 = ignore   # ignore/add/remove/force
+nl_after_member                 = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to double-space commented-entries in 'struct'/'union'/'enum'.
 nl_ds_struct_enum_cmt           = false    # true/false
@@ -1931,15 +2251,15 @@ nl_ds_struct_enum_close_brace   = false    # true/false
 
 # Add or remove newline before or after (depending on pos_class_colon) a class
 # colon, as in 'class Foo <here> : <or here> public Bar'.
-nl_class_colon                  = ignore   # ignore/add/remove/force
+nl_class_colon                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline around a class constructor colon. The exact position
 # depends on nl_constr_init_args, pos_constr_colon and pos_constr_comma.
-nl_constr_colon                 = add      # ignore/add/remove/force
+nl_constr_colon                 = add      # ignore/add/remove/force/not_defined
 
 # Whether to collapse a two-line namespace, like 'namespace foo\n{ decl; }'
 # into a single line. If true, prevents other brace newline rules from turning
-# such code into four lines.
+# such code into four lines. If true, it also preserves one-liner namespaces.
 nl_namespace_two_to_one_liner   = false    # true/false
 
 # Whether to remove a newline in simple unbraced if statements, turning them
@@ -1959,9 +2279,8 @@ nl_create_while_one_liner       = false    # true/false
 # a single line.
 nl_create_func_def_one_liner    = false    # true/false
 
-# Whether to collapse a function definition whose body (not counting braces)
-# is only one line so that the entire definition (prototype, braces, body) is
-# a single line.
+# Whether to split one-line simple list definitions into three lines by
+# adding newlines, as in 'int a[12] = { <here> 0 <here> };'.
 nl_create_list_one_liner        = false    # true/false
 
 # Whether to split one-line simple unbraced if statements into two lines by
@@ -1976,11 +2295,9 @@ nl_split_for_one_liner          = false    # true/false
 # adding a newline, as in 'while (expr) <here> stmt;'.
 nl_split_while_one_liner        = false    # true/false
 
-# Newline between do and open brace
-nl_do_brace                     = add      # string (add/force/ignore/remove)
-
-# Newline between close brace and while
-nl_brace_while                  = add      # string (add/force/ignore/remove)
+# Don't add a newline before a cpp-comment in a parameter list of a function
+# call.
+donot_add_nl_before_cpp_comment = false    # true/false
 
 #
 # Blank line options
@@ -1992,10 +2309,17 @@ nl_max                          = 0        # unsigned number
 # The maximum number of consecutive newlines in a function.
 nl_max_blank_in_func            = 0        # unsigned number
 
+# The number of newlines inside an empty function body.
+# This option overrides eat_blanks_after_open_brace and
+# eat_blanks_before_close_brace, but is ignored when
+# nl_collapse_empty_body_functions=true
+nl_inside_empty_func            = 0        # unsigned number
+
 # The number of newlines before a function prototype.
 nl_before_func_body_proto       = 0        # unsigned number
 
-# The number of newlines before a multi-line function definition.
+# The number of newlines before a multi-line function definition. Where
+# applicable, this option is overridden with eat_blanks_after_open_brace=true
 nl_before_func_body_def         = 0        # unsigned number
 
 # The number of newlines before a class constructor/destructor prototype.
@@ -2026,7 +2350,20 @@ nl_after_func_class_proto_group = 0        # unsigned number
 nl_class_leave_one_liner_groups = false    # true/false
 
 # The number of newlines after '}' of a multi-line function body.
+#
+# Overrides nl_min_after_func_body and nl_max_after_func_body.
 nl_after_func_body              = 2        # unsigned number
+
+# The minimum number of newlines after '}' of a multi-line function body.
+#
+# Only works when nl_after_func_body is 0.
+nl_min_after_func_body          = 0        # unsigned number
+
+# The maximum number of newlines after '}' of a multi-line function body.
+#
+# Only works when nl_after_func_body is 0.
+# Takes precedence over nl_min_after_func_body.
+nl_max_after_func_body          = 0        # unsigned number
 
 # The number of newlines after '}' of a multi-line function body in a class
 # declaration. Also affects class constructors/destructors.
@@ -2039,12 +2376,6 @@ nl_after_func_body_class        = 0        # unsigned number
 #
 # Overrides nl_after_func_body and nl_after_func_body_class.
 nl_after_func_body_one_liner    = 0        # unsigned number
-
-# The number of blank lines after a block of variable definitions at the top
-# of a function body.
-#
-# 0: No change (default).
-nl_var_def_blk_end_func_top     = 0        # unsigned number
 
 # The number of newlines before a block of typedefs. If nl_after_access_spec
 # is non-zero, that option takes precedence.
@@ -2062,15 +2393,27 @@ nl_typedef_blk_end              = 0        # unsigned number
 # 0: No change (default).
 nl_typedef_blk_in               = 0        # unsigned number
 
-# The number of newlines before a block of variable definitions not at the top
-# of a function body. If nl_after_access_spec is non-zero, that option takes
-# precedence.
+# The minimum number of blank lines after a block of variable definitions
+# at the top of a function body. If any preprocessor directives appear
+# between the opening brace of the function and the variable block, then
+# it is considered as not at the top of the function.Newlines are added
+# before trailing preprocessor directives, if any exist.
+#
+# 0: No change (default).
+nl_var_def_blk_end_func_top     = 0        # unsigned number
+
+# The minimum number of empty newlines before a block of variable definitions
+# not at the top of a function body. If nl_after_access_spec is non-zero,
+# that option takes precedence. Newlines are not added at the top of the
+# file or just after an opening brace. Newlines are added above any
+# preprocessor directives before the block.
 #
 # 0: No change (default).
 nl_var_def_blk_start            = 0        # unsigned number
 
-# The number of newlines after a block of variable definitions not at the top
-# of a function body.
+# The minimum number of empty newlines after a block of variable definitions
+# not at the top of a function body. Newlines are not added if the block
+# is at the bottom of the file or just before a preprocessor directive.
 #
 # 0: No change (default).
 nl_var_def_blk_end              = 0        # unsigned number
@@ -2098,6 +2441,9 @@ nl_after_multiline_comment      = false    # true/false
 
 # Whether to force a newline after a label's colon.
 nl_after_label_colon            = false    # true/false
+
+# The number of newlines before a struct definition.
+nl_before_struct                = 0        # unsigned number
 
 # The number of newlines after '}' or ';' of a struct/enum/union definition.
 nl_after_struct                 = 0        # unsigned number
@@ -2163,7 +2509,7 @@ nl_around_cs_property           = 0        # unsigned number
 nl_between_get_set              = 0        # unsigned number
 
 # (C#) Add or remove newline between property and the '{'.
-nl_property_brace               = ignore   # ignore/add/remove/force
+nl_property_brace               = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to remove blank lines after '{'.
 eat_blanks_after_open_brace     = false    # true/false
@@ -2180,10 +2526,10 @@ nl_remove_extra_newlines        = 0        # unsigned number
 
 # (Java) Add or remove newline after an annotation statement. Only affects
 # annotations that are after a newline.
-nl_after_annotation             = ignore   # ignore/add/remove/force
+nl_after_annotation             = ignore   # ignore/add/remove/force/not_defined
 
 # (Java) Add or remove newline between two annotations.
-nl_between_annotation           = ignore   # ignore/add/remove/force
+nl_between_annotation           = ignore   # ignore/add/remove/force/not_defined
 
 # The number of newlines before a whole-file #ifdef.
 #
@@ -2247,6 +2593,9 @@ pos_class_colon                 = ignore   # ignore/break/force/lead/trail/join/
 # The position of colons between constructor and member initialization.
 # Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.
 pos_constr_colon                = lead     # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
+
+# The position of shift operators in wrapped expressions.
+pos_shift                       = ignore   # ignore/break/force/lead/trail/join/lead_break/lead_force/trail_break/trail_force
 
 #
 # Line splitting options
@@ -2391,6 +2740,22 @@ align_assign_func_proto_span    = 0        # unsigned number
 # 0: No limit (default).
 align_assign_thresh             = 0        # number
 
+# Whether to align on the left most assignment when multiple
+# definitions are found on the same line.
+# Depends on 'align_assign_span' and 'align_assign_thresh' settings.
+align_assign_on_multi_var_defs  = false    # true/false
+
+# The span for aligning on '{' in braced init list.
+#
+# 0: Don't align (default).
+align_braced_init_list_span     = 0        # unsigned number
+
+# The threshold for aligning on '{' in braced init list.
+# Use a negative number for absolute thresholds.
+#
+# 0: No limit (default).
+align_braced_init_list_thresh   = 0        # number
+
 # How to apply align_assign_span to function declaration "assignments", i.e.
 # 'virtual void foo() = 0' or '~foo() = {default|delete}'.
 #
@@ -2503,6 +2868,29 @@ align_right_cmt_at_col          = 0        # unsigned number
 # 0: Don't align (default).
 align_func_proto_span           = 0        # unsigned number
 
+# Whether to ignore continuation lines when evaluating the number of
+# new lines for the function prototype alignment's span.
+#
+# false: continuation lines are part of the newlines count
+# true:  continuation lines are not counted
+align_func_proto_span_ignore_cont_lines = false    # true/false
+
+# How to consider (or treat) the '*' in the alignment of function prototypes.
+#
+# 0: Part of the type     'void *   foo();' (default)
+# 1: Part of the function 'void     *foo();'
+# 2: Dangling             'void    *foo();'
+# Dangling: the '*' will not be taken into account when aligning.
+align_func_proto_star_style     = 0        # unsigned number
+
+# How to consider (or treat) the '&' in the alignment of function prototypes.
+#
+# 0: Part of the type     'long &   foo();' (default)
+# 1: Part of the function 'long     &foo();'
+# 2: Dangling             'long    &foo();'
+# Dangling: the '&' will not be taken into account when aligning.
+align_func_proto_amp_style      = 0        # unsigned number
+
 # The threshold for aligning function prototypes.
 # Use a negative number for absolute thresholds.
 #
@@ -2536,9 +2924,22 @@ align_single_line_brace_gap     = 0        # unsigned number
 # 0: Don't align (default).
 align_oc_msg_spec_span          = 0        # unsigned number
 
-# Whether to align macros wrapped with a backslash and a newline. This will
-# not work right if the macro contains a multi-line comment.
-align_nl_cont                   = 0        # true:1/false:0
+# Whether and how to align backslashes that split a macro onto multiple lines.
+# This will not work right if the macro contains a multi-line comment.
+#
+# 0: Do nothing (default)
+# 1: Align the backslashes in the column at the end of the longest line
+# 2: Align with the backslash that is farthest to the left, or, if that
+#    backslash is farther left than the end of the longest line, at the end of
+#    the longest line
+# 3: Align with the backslash that is farthest to the right
+align_nl_cont                   = 0        # unsigned number
+
+# The minimum number of spaces between the end of a line and its continuation
+# backslash. Requires align_nl_cont.
+#
+# Default: 1
+align_nl_cont_spaces            = 1        # unsigned number
 
 # Whether to align macro functions and variables together.
 align_pp_define_together        = false    # true/false
@@ -2556,6 +2957,10 @@ align_pp_define_gap             = 0        # unsigned number
 #
 # Default: true
 align_left_shift                = true     # true/false
+
+# Whether to align comma-separated statements following '<<' (as used to
+# initialize Eigen matrices).
+align_eigen_comma_init          = false    # true/false
 
 # Whether to align text after 'asm volatile ()' colons.
 align_asm_colon                 = false    # true/false
@@ -2576,7 +2981,7 @@ align_oc_decl_colon             = false    # true/false
 
 # (OC) Whether to not align parameters in an Objectve-C message call if first
 # colon is not on next line of the message call (the same way Xcode does
-# aligment)
+# alignment)
 align_oc_msg_colon_xcode_like   = false    # true/false
 
 #
@@ -2590,8 +2995,43 @@ cmt_width                       = 0        # unsigned number
 #
 # 0: No reflowing (apart from the line wrapping due to cmt_width) (default)
 # 1: No touching at all
-# 2: Full reflow
+# 2: Full reflow (enable cmt_indent_multi for indent with line wrapping due to cmt_width)
 cmt_reflow_mode                 = 0        # unsigned number
+
+# Path to a file that contains regular expressions describing patterns for
+# which the end of one line and the beginning of the next will be folded into
+# the same sentence or paragraph during full comment reflow. The regular
+# expressions are described using ECMAScript syntax. The syntax for this
+# specification is as follows, where "..." indicates the custom regular
+# expression and "n" indicates the nth end_of_prev_line_regex and
+# beg_of_next_line_regex regular expression pair:
+#
+# end_of_prev_line_regex[1] = "...$"
+# beg_of_next_line_regex[1] = "^..."
+# end_of_prev_line_regex[2] = "...$"
+# beg_of_next_line_regex[2] = "^..."
+#             .
+#             .
+#             .
+# end_of_prev_line_regex[n] = "...$"
+# beg_of_next_line_regex[n] = "^..."
+#
+# Note that use of this option overrides the default reflow fold regular
+# expressions, which are internally defined as follows:
+#
+# end_of_prev_line_regex[1] = "[\w,\]\)]$"
+# beg_of_next_line_regex[1] = "^[\w,\[\(]"
+# end_of_prev_line_regex[2] = "\.$"
+# beg_of_next_line_regex[2] = "^[A-Z]"
+cmt_reflow_fold_regex_file      = ""         # string
+
+# Whether to indent wrapped lines to the start of the encompassing paragraph
+# during full comment reflow (cmt_reflow_mode = 2). Overrides the value
+# specified by cmt_sp_after_star_cont.
+#
+# Note that cmt_align_doxygen_javadoc_tags overrides this option for
+# paragraphs associated with javadoc tags
+cmt_reflow_indent_to_paragraph_start = false    # true/false
 
 # Whether to convert all tabs to spaces in comments. If false, tabs in
 # comments are left alone, unless used for indenting.
@@ -2602,6 +3042,25 @@ cmt_convert_tab_to_spaces       = false    # true/false
 #
 # Default: true
 cmt_indent_multi                = true     # true/false
+
+# Whether to align doxygen javadoc-style tags ('@param', '@return', etc.)
+# and corresponding fields such that groups of consecutive block tags,
+# parameter names, and descriptions align with one another. Overrides that
+# which is specified by the cmt_sp_after_star_cont. If cmt_width > 0, it may
+# be necessary to enable cmt_indent_multi and set cmt_reflow_mode = 2
+# in order to achieve the desired alignment for line-wrapping.
+cmt_align_doxygen_javadoc_tags  = false    # true/false
+
+# The number of spaces to insert after the star and before doxygen
+# javadoc-style tags (@param, @return, etc). Requires enabling
+# cmt_align_doxygen_javadoc_tags. Overrides that which is specified by the
+# cmt_sp_after_star_cont.
+#
+# Default: 1
+cmt_sp_before_doxygen_javadoc_tags = 1        # unsigned number
+
+# Whether to change trailing, single-line c-comments into cpp-comments.
+cmt_trailing_single_line_c_to_cpp = false    # true/false
 
 # Whether to group c-comments that look like they are in a block.
 cmt_c_group                     = false    # true/false
@@ -2709,25 +3168,30 @@ cmt_insert_before_ctor_dtor     = false    # true/false
 #
 
 # Add or remove braces on a single-line 'do' statement.
-mod_full_brace_do               = add      # ignore/add/remove/force
+mod_full_brace_do               = add      # ignore/add/remove/force/not_defined
 
 # Add or remove braces on a single-line 'for' statement.
-mod_full_brace_for              = add      # ignore/add/remove/force
+mod_full_brace_for              = add      # ignore/add/remove/force/not_defined
 
 # (Pawn) Add or remove braces on a single-line function definition.
-mod_full_brace_function         = add      # ignore/add/remove/force
+mod_full_brace_function         = add      # ignore/add/remove/force/not_defined
 
 # Add or remove braces on a single-line 'if' statement. Braces will not be
 # removed if the braced statement contains an 'else'.
-mod_full_brace_if               = add      # ignore/add/remove/force
+mod_full_brace_if               = add      # ignore/add/remove/force/not_defined
 
 # Whether to enforce that all blocks of an 'if'/'else if'/'else' chain either
-# have, or do not have, braces. If true, braces will be added if any block
-# needs braces, and will only be removed if they can be removed from all
-# blocks.
+# have, or do not have, braces. Overrides mod_full_brace_if.
 #
-# Overrides mod_full_brace_if.
-mod_full_brace_if_chain         = 0        # true:1/false:0
+# 0: Don't override mod_full_brace_if
+# 1: Add braces to all blocks if any block needs braces and remove braces if
+#    they can be removed from all blocks
+# 2: Add braces to all blocks if any block already has braces, regardless of
+#    whether it needs them
+# 3: Add braces to all blocks if any block needs braces and remove braces if
+#    they can be removed from all blocks, except if all blocks have braces
+#    despite none needing them
+mod_full_brace_if_chain         = 0        # unsigned number
 
 # Whether to add braces to all blocks of an 'if'/'else if'/'else' chain.
 # If true, mod_full_brace_if_chain will only remove braces from an 'if' that
@@ -2735,10 +3199,10 @@ mod_full_brace_if_chain         = 0        # true:1/false:0
 mod_full_brace_if_chain_only    = false    # true/false
 
 # Add or remove braces on single-line 'while' statement.
-mod_full_brace_while            = add      # ignore/add/remove/force
+mod_full_brace_while            = add      # ignore/add/remove/force/not_defined
 
 # Add or remove braces on single-line 'using ()' statement.
-mod_full_brace_using            = ignore   # ignore/add/remove/force
+mod_full_brace_using            = ignore   # ignore/add/remove/force/not_defined
 
 # Don't remove braces around statements that span N newlines
 mod_full_brace_nl               = 0        # unsigned number
@@ -2759,8 +3223,11 @@ mod_full_brace_nl               = 0        # unsigned number
 #   mod_full_brace_function
 mod_full_brace_nl_block_rem_mlcond = false    # true/false
 
-# Add or remove unnecessary parenthesis on 'return' statement.
-mod_paren_on_return             = ignore   # ignore/add/remove/force
+# Add or remove unnecessary parentheses on 'return' statement.
+mod_paren_on_return             = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove unnecessary parentheses on 'throw' statement.
+mod_paren_on_throw              = ignore   # ignore/add/remove/force/not_defined
 
 # (Pawn) Whether to change optional semicolons to real semicolons.
 mod_pawn_semicolon              = false    # true/false
@@ -2769,8 +3236,25 @@ mod_pawn_semicolon              = false    # true/false
 # statement, as in 'if (a && b > c)' => 'if (a && (b > c))'.
 mod_full_paren_if_bool          = false    # true/false
 
+# Whether to fully parenthesize Boolean expressions after '='
+# statement, as in 'x = a && b > c;' => 'x = (a && (b > c));'.
+mod_full_paren_assign_bool      = false    # true/false
+
+# Whether to fully parenthesize Boolean expressions after '='
+# statement, as in 'return  a && b > c;' => 'return (a && (b > c));'.
+mod_full_paren_return_bool      = false    # true/false
+
 # Whether to remove superfluous semicolons.
 mod_remove_extra_semicolon      = true     # true/false
+
+# Whether to remove duplicate include.
+mod_remove_duplicate_include    = false    # true/false
+
+# the following options (mod_XX_closebrace_comment) use different comment,
+# depending of the setting of the next option.
+# false: Use the c comment (default)
+# true : Use the cpp comment
+mod_add_force_c_closebrace_comment = false    # true/false
 
 # If a function body exceeds the specified number of newlines and doesn't have
 # a comment after the close brace, a comment will be added.
@@ -2833,16 +3317,63 @@ mod_sort_incl_import_grouping_enabled = false    # true/false
 # the close brace, as in 'case X: { ... } break;' => 'case X: { ... break; }'.
 mod_move_case_break             = false    # true/false
 
+# Whether to move a 'return' that appears after a fully braced 'case' before
+# the close brace, as in 'case X: { ... } return;' => 'case X: { ... return; }'.
+mod_move_case_return            = false    # true/false
+
 # Add or remove braces around a fully braced case statement. Will only remove
 # braces if there are no variable declarations in the block.
-mod_case_brace                  = ignore   # ignore/add/remove/force
+mod_case_brace                  = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to remove a void 'return;' that appears as the last statement in a
 # function.
 mod_remove_empty_return         = false    # true/false
 
 # Add or remove the comma after the last value of an enumeration.
-mod_enum_last_comma             = ignore   # ignore/add/remove/force
+mod_enum_last_comma             = ignore   # ignore/add/remove/force/not_defined
+
+# Syntax to use for infinite loops.
+#
+# 0: Leave syntax alone (default)
+# 1: Rewrite as `for(;;)`
+# 2: Rewrite as `while(true)`
+# 3: Rewrite as `do`...`while(true);`
+# 4: Rewrite as `while(1)`
+# 5: Rewrite as `do`...`while(1);`
+#
+# Infinite loops that do not already match one of these syntaxes are ignored.
+# Other options that affect loop formatting will be applied after transforming
+# the syntax.
+mod_infinite_loop               = 0        # unsigned number
+
+# Add or remove the 'int' keyword in 'int short'.
+mod_int_short                   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'short int'.
+mod_short_int                   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'int long'.
+mod_int_long                    = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'long int'.
+mod_long_int                    = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'int signed'.
+mod_int_signed                  = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'signed int'.
+mod_signed_int                  = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'int unsigned'.
+mod_int_unsigned                = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'unsigned int'.
+mod_unsigned_int                = ignore   # ignore/add/remove/force/not_defined
+
+# If there is a situation where mod_int_* and mod_*_int would result in
+# multiple int keywords, whether to keep the rightmost int (the default) or the
+# leftmost int.
+mod_int_prefer_int_on_left      = false    # true/false
 
 # (OC) Whether to organize the properties. If true, properties will be
 # rearranged according to the mod_sort_oc_property_*_weight factors.
@@ -2875,13 +3406,27 @@ mod_sort_oc_property_nullability_weight = 0        # number
 # Preprocessor options
 #
 
+# How to use tabs when indenting preprocessor code.
+#
+# -1: Use 'indent_with_tabs' setting (default)
+#  0: Spaces only
+#  1: Indent with tabs to brace level, align with spaces
+#  2: Indent and align with tabs, using spaces when not on a tabstop
+#
+# Default: -1
+pp_indent_with_tabs             = -1       # number
+
 # Add or remove indentation of preprocessor directives inside #if blocks
 # at brace level 0 (file-level).
-pp_indent                       = ignore   # ignore/add/remove/force
+pp_indent                       = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to indent #if/#else/#endif at the brace level. If false, these are
 # indented from column 1.
 pp_indent_at_level              = false    # true/false
+
+# Whether to indent #if/#else/#endif at the parenthesis level if the brace
+# level is 0. If false, these are indented from column 1.
+pp_indent_at_level0             = false    # true/false
 
 # Specifies the number of columns to indent preprocessors per level
 # at brace level 0 (file-level). If pp_indent_at_level=false, also specifies
@@ -2891,10 +3436,10 @@ pp_indent_at_level              = false    # true/false
 # Default: 1
 pp_indent_count                 = 1        # unsigned number
 
-# Add or remove space after # based on pp_level of #if blocks.
-pp_space_after                  = ignore   # ignore/add/remove/force
+# Add or remove space after # based on pp level of #if blocks.
+pp_space_after                  = ignore   # ignore/add/remove/force/not_defined
 
-# Sets the number of spaces per level added with pp_space.
+# Sets the number of spaces per level added with pp_space_after.
 pp_space_count                  = 0        # unsigned number
 
 # The indent for '#region' and '#endregion' in C# and '#pragma region' in
@@ -2914,40 +3459,83 @@ pp_indent_if                    = 0        # number
 # Whether to indent the code between #if, #else and #endif.
 pp_if_indent_code               = false    # true/false
 
+# Whether to indent the body of an #if that encompasses all the code in the file.
+pp_indent_in_guard              = false    # true/false
+
 # Whether to indent '#define' at the brace level. If false, these are
 # indented from column 1.
 pp_define_at_level              = false    # true/false
 
+# Whether to indent '#include' at the brace level.
+pp_include_at_level             = false    # true/false
+
 # Whether to ignore the '#define' body while formatting.
 pp_ignore_define_body           = false    # true/false
 
+# An offset value that controls the indentation of the body of a multiline #define.
+# 'body' refers to all the lines of a multiline #define except the first line.
+# Requires 'pp_ignore_define_body = false'.
+#
+#  <0: Absolute column: the body indentation starts off at the specified column
+#      (ex. -3 ==> the body is indented starting from column 3)
+# >=0: Relative to the column of the '#' of '#define'
+#      (ex.  3 ==> the body is indented starting 3 columns at the right of '#')
+#
+# Default: 8
+pp_multiline_define_body_indent = 8        # number
+
 # Whether to indent case statements between #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the case statements
+# Only applies to the indent of the preprocessor that the case statements
 # directly inside of.
 #
 # Default: true
 pp_indent_case                  = true     # true/false
 
 # Whether to indent whole function definitions between #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the function definition
+# Only applies to the indent of the preprocessor that the function definition
 # is directly inside of.
 #
 # Default: true
 pp_indent_func_def              = true     # true/false
 
 # Whether to indent extern C blocks between #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the extern block is
+# Only applies to the indent of the preprocessor that the extern block is
 # directly inside of.
 #
 # Default: true
 pp_indent_extern                = true     # true/false
 
-# Whether to indent braces directly inside #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the braces are directly
-# inside of.
+# How to indent braces directly inside #if, #else, and #endif.
+# Requires pp_if_indent_code=true and only applies to the indent of the
+# preprocessor that the braces are directly inside of.
+#  0: No extra indent
+#  1: Indent by one level
+# -1: Preserve original indentation
 #
-# Default: true
-pp_indent_brace                 = 1        # true:1/false:0
+# Default: 1
+pp_indent_brace                 = 1        # number
+
+# Whether to print warning messages for unbalanced #if and #else blocks.
+# This will print a message in the following cases:
+# - if an #ifdef block ends on a different indent level than
+#   where it started from. Example:
+#
+#    #ifdef TEST
+#      int i;
+#      {
+#        int j;
+#    #endif
+#
+# - an #elif/#else block ends on a different indent level than
+#   the corresponding #ifdef block. Example:
+#
+#    #ifdef TEST
+#        int i;
+#    #else
+#        }
+#      int j;
+#    #endif
+pp_warn_unbalanced_if           = false    # true/false
 
 #
 # Sort includes options
@@ -2986,17 +3574,16 @@ use_indent_func_call_param      = true     # true/false
 #
 # true:  indent_continue will be used only once
 # false: indent_continue will be used every time (default)
+#
+# Requires indent_ignore_first_continue=false.
 use_indent_continue_only_once   = false    # true/false
 
-# The value might be used twice:
-# - at the assignment
-# - at the opening brace
+# The indentation can be:
+# - after the assignment, at the '[' character
+# - at the beginning of the lambda body
 #
-# To prevent the double use of the indentation value, use this option with the
-# value 'true'.
-#
-# true:  indentation will be used only once
-# false: indentation will be used every time (default)
+# true:  indentation will be at the beginning of the lambda body
+# false: indentation will be after the assignment (default)
 indent_cpp_lambda_only_once     = false    # true/false
 
 # Whether sp_after_angle takes precedence over sp_inside_fparen. This was the
@@ -3015,9 +3602,8 @@ use_sp_after_angle_always       = false    # true/false
 # Default: true
 use_options_overriding_for_qt_macros = true     # true/false
 
-# If true: the form feed character is removed from the list
-# of whitespace characters.
-# See https://en.cppreference.com/w/cpp/string/byte/isspace
+# If true: the form feed character is removed from the list of whitespace
+# characters. See https://en.cppreference.com/w/cpp/string/byte/isspace.
 use_form_feed_no_more_as_whitespace_character = false    # true/false
 
 #
@@ -3039,6 +3625,32 @@ debug_max_number_of_loops       = 0        # number
 # Used in the function prot_the_line if the 2. parameter is zero.
 # 0: nothing protocol.
 debug_line_number_to_protocol   = 0        # number
+
+# Set the number of second(s) before terminating formatting the current file,
+# 0: no timeout.
+# only for linux
+debug_timeout                   = 0        # number
+
+# Set the number of characters to be printed if the text is too long,
+# 0: do not truncate.
+debug_truncate                  = 0        # unsigned number
+
+# sort (or not) the tracking info.
+#
+# Default: true
+debug_sort_the_tracks           = true     # true/false
+
+# decode (or not) the flags as a new line.
+# only if the -p option is set.
+debug_decode_the_flags          = false    # true/false
+
+# use (or not) the exit(EX_SOFTWARE) function.
+#
+# Default: true
+debug_use_the_exit_function_pop = true     # true/false
+
+# insert the number of the line at the beginning of each line
+set_numbering_for_html_output   = false    # true/false
 
 # Meaning of the settings:
 #   Ignore - do not do any changes
@@ -3092,5 +3704,5 @@ debug_line_number_to_protocol   = 0        # number
 #       `macro-close END_MESSAGE_MAP`
 #
 #
-# option(s) with 'not default' value: 62
+# option(s) with 'not default' value: 81
 #


### PR DESCRIPTION
Default uncrustify version in Ubuntu 24.04 is Uncrustify-0.78.1_f, compared with Uncrustify-0.72.0_f (default version in Ubuntu 22.04).

This new version raises several deprecation warnings when reading eProsima uncrustify.cfg file. 
