### PR TITLE
[#24079] Update `uncrustify.cfg` for new 0.78.1 style

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1947,7 +1947,7 @@ nl_class_init_args              = ignore   # ignore/add/remove/force/not_defined
 # Add or remove newline after each ',' in the constructor member
 # initialization. Related to nl_constr_colon, pos_constr_colon and
 # pos_constr_comma.
-nl_constr_init_args             = ignore      # ignore/add/remove/force/not_defined
+nl_constr_init_args             = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline before first element, after comma, and after last
 # element, in 'enum'.
@@ -2000,13 +2000,13 @@ nl_func_call_paren_empty        = ignore   # ignore/add/remove/force/not_defined
 nl_func_decl_start              = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline after '(' in a function definition.
-nl_func_def_start               = add   # ignore/add/remove/force/not_defined
+nl_func_def_start               = add      # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_decl_start when there is only one parameter.
 nl_func_decl_start_single       = add      # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_def_start when there is only one parameter.
-nl_func_def_start_single        = add   # ignore/add/remove/force/not_defined
+nl_func_def_start_single        = add      # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after '(' in a function declaration if '(' and ')'
 # are in different lines. If false, nl_func_decl_start is used instead.

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1198,7 +1198,7 @@ indent_brace_parent             = false    # true/false
 
 # Whether to indent based on the open parenthesis instead of the open brace
 # in '({\n'.
-indent_paren_open_brace         = false    # true/false
+indent_paren_open_brace         = true     # true/false
 
 # (C#) Whether to indent the brace of a C# delegate by another level.
 indent_cs_delegate_brace        = false    # true/false

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -3,6 +3,7 @@
 #
 # General options
 #
+file_ext CPP .ipp .cxx
 
 # The type of line endings.
 #
@@ -335,17 +336,17 @@ sp_before_template_paren        = ignore   # ignore/add/remove/force/not_defined
 sp_template_angle               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before '<'.
-sp_before_angle                 = ignore   # ignore/add/remove/force/not_defined
+sp_before_angle                 = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '<' and '>'.
-sp_inside_angle                 = ignore   # ignore/add/remove/force/not_defined
+sp_inside_angle                 = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '<>'.
 # if empty.
-sp_inside_angle_empty           = ignore   # ignore/add/remove/force/not_defined
+sp_inside_angle_empty           = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '>' and ':'.
-sp_angle_colon                  = ignore   # ignore/add/remove/force/not_defined
+sp_angle_colon                  = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after '>'.
 sp_after_angle                  = ignore   # ignore/add/remove/force/not_defined
@@ -847,10 +848,10 @@ sp_word_brace_init_lst          = ignore   # ignore/add/remove/force/not_defined
 sp_word_brace_ns                = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space before the '::' operator.
-sp_before_dc                    = ignore   # ignore/add/remove/force/not_defined
+sp_before_dc                    = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '::' operator.
-sp_after_dc                     = ignore   # ignore/add/remove/force/not_defined
+sp_after_dc                     = remove   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove around the D named array initializer ':' operator.
 sp_d_array_colon                = ignore   # ignore/add/remove/force/not_defined
@@ -1630,7 +1631,7 @@ indent_ignore_asm_block         = false    # true/false
 
 # Don't indent the close parenthesis of a function definition,
 # if the parenthesis is on its own line.
-donot_indent_func_def_close_paren = false    # true/false
+donot_indent_func_def_close_paren = true   # true/false
 
 #
 # Newline adding and removing options
@@ -1947,7 +1948,7 @@ nl_class_init_args              = ignore   # ignore/add/remove/force/not_defined
 # Add or remove newline after each ',' in the constructor member
 # initialization. Related to nl_constr_colon, pos_constr_colon and
 # pos_constr_comma.
-nl_constr_init_args             = add      # ignore/add/remove/force/not_defined
+nl_constr_init_args             = ignore      # ignore/add/remove/force/not_defined
 
 # Add or remove newline before first element, after comma, and after last
 # element, in 'enum'.
@@ -2000,13 +2001,13 @@ nl_func_call_paren_empty        = ignore   # ignore/add/remove/force/not_defined
 nl_func_decl_start              = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline after '(' in a function definition.
-nl_func_def_start               = add      # ignore/add/remove/force/not_defined
+nl_func_def_start               = ignore   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_decl_start when there is only one parameter.
 nl_func_decl_start_single       = add      # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_def_start when there is only one parameter.
-nl_func_def_start_single        = add      # ignore/add/remove/force/not_defined
+nl_func_def_start_single        = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after '(' in a function declaration if '(' and ')'
 # are in different lines. If false, nl_func_decl_start is used instead.
@@ -2143,7 +2144,7 @@ nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force/not_defined
 nl_before_brace_open            = false    # true/false
 
 # Whether to add a newline after '{'.
-nl_after_brace_open             = true     # true/false
+nl_after_brace_open             = false    # true/false
 
 # Whether to add a newline between the open brace and a trailing single-line
 # comment. Requires nl_after_brace_open=true.
@@ -2159,7 +2160,7 @@ nl_after_vbrace_open_empty      = false    # true/false
 
 # Whether to add a newline after '}'. Does not apply if followed by a
 # necessary ';'.
-nl_after_brace_close            = true     # true/false
+nl_after_brace_close            = false     # true/false
 
 # Whether to add a newline after a virtual brace close,
 # as in 'if (foo) a++; <here> return;'.

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -3,7 +3,6 @@
 #
 # General options
 #
-file_ext CPP .ipp .cxx
 
 # The type of line endings.
 #
@@ -2001,13 +2000,13 @@ nl_func_call_paren_empty        = ignore   # ignore/add/remove/force/not_defined
 nl_func_decl_start              = add      # ignore/add/remove/force/not_defined
 
 # Add or remove newline after '(' in a function definition.
-nl_func_def_start               = ignore   # ignore/add/remove/force/not_defined
+nl_func_def_start               = add   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_decl_start when there is only one parameter.
 nl_func_decl_start_single       = add      # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_def_start when there is only one parameter.
-nl_func_def_start_single        = ignore   # ignore/add/remove/force/not_defined
+nl_func_def_start_single        = add   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after '(' in a function declaration if '(' and ')'
 # are in different lines. If false, nl_func_decl_start is used instead.


### PR DESCRIPTION
## CHECKED

- ```indent_paren_open_brace```

```cpp
// indent_paren_open_brace         = true     #

// Original
INSTANTIATE_TEST_SUITE_P(
    HistoryDepthTests,
    HistoryDepthParameterizedTest,
    ::testing::Values(
        // Keyed type: max_samples_per_instance takes precedence over depth
        HistoryDepthTestParams{
    "KeyedType_MaxSamplesPerInstance",
    true,          // use_keyed_type
    KEEP_LAST_HISTORY_QOS,
    100,           // depth
    400,           // max_samples
    5,             // max_samples_per_instance
    120,           // num_samples_to_write
    5,             // expected_samples
    "Expected max_samples_per_instance (5) samples, not depth (100)"
},
);

// Uncrustify
INSTANTIATE_TEST_SUITE_P(
    HistoryDepthTests,
    HistoryDepthParameterizedTest,
    ::testing::Values(
        // Keyed type: max_samples_per_instance takes precedence over depth
        HistoryDepthTestParams{
            "KeyedType_MaxSamplesPerInstance",
            true,  // use_keyed_type
            KEEP_LAST_HISTORY_QOS,
            100,   // depth
            400,   // max_samples
            5,     // max_samples_per_instance
            120,   // num_samples_to_write
            5,     // expected_samples
            "Expected max_samples_per_instance (5) samples, not depth (100)"
        },
        ),
    [](const testing::TestParamInfo<HistoryDepthTestParams>& info)
    {
        return info.param.test_name;
    }
    );

// No other crucial changes found
```


- ```sp_inside_angle```

```cpp
//sp_inside_angle                 = remove

// -- CHANGES --

// Original
template < typename  CommandEnum >

template <typename CommandEnum>
// Original
bool CommandReader< CommandEnum  >();
// Uncrustify
bool CommandReader<CommandEnum>();
```

- ```sp_before_angle```

```cpp
//sp_before_angle                 = remove

// -- CHANGES --
// Original
template <typename CommandEnum>
// Uncrustify
template<typename CommandEnum>
// Original
bool CommandReader <CommandEnum>()
// Uncrustify
bool CommandReader<CommandEnum>()
```

- ```sp_inside_angle_empty```

```cpp
//sp_inside_angle_empty           = remove

// -- CHANGES --
<  > -> <>
```


- ```sp_before_dc | sp_after_dc```

```cpp
//sp_before_dc                    = remove
//sp_after_dc                     = remove

// -- CHANGES --
// Original
bool CommandReader<CommandEnum> :: read_next_command()
// Uncrustify
bool CommandReader<CommandEnum>::read_next_command()
```


- ```nl_after_brace_close```

```cpp
//nl_after_brace_close            = true     // true/false


// -- CHANGES --

// DOES NOT CHANGE
#define MACRO_BAD_BLOCK(a) if (a){ std::puts("yes"); } else { std::puts("no"); }

// Original
#define MACRO_BAD_BLOCK(a) if (a){ std::puts("yes"); }
    else { std::puts("no"); }

// Uncrustify
#define MACRO_BAD_BLOCK(a) if (a){ std::puts("yes"); }
else
{
    std::puts("no");
}


// Originals
if()
{
    x=1;
} else if()
{
    x=10;
}

if(){ x = 1;}else if (){x = 10;}

// Uncrustify
if ()
{
    x = 1;
}
else if ()
{
    x = 10;
}

```



- ```nl_after_brace_open```

```cpp
//nl_after_brace_open             = false     # true/false

// -- CHANGES --

// DOES NOT CHANGE
enum   class  Color:std::uint8_t { Red=1, Green=2, Blue=3 };

// Original
enum   class  Color:std::uint8_t {
    Red=1, Green=2, Blue=3 };

// Uncrustify
enum   class  Color:std::uint8_t
{
    Red=1, Green=2, Blue=3
};

// Original
if(){

}

// Uncrustify
if()
{

}

// Original
RemoteInvalidArgumentError()
    : RemoteInvalidArgumentError("The value of a parameter passed has an illegal value"){
}

// Uncrustify
RemoteInvalidArgumentError()
    : RemoteInvalidArgumentError("The value of a parameter passed has an illegal value")
{
}

```


## REJECT CHANGE

It is better to move all arguments one line rather than ignoring and leave constructor arguments in the same line.

- ```nl_func_def_start | nl_func_def_start_single```

```cpp
// Add or remove newline after '(' in a function definition.
//nl_func_def_start               = ignore      // original -> add
// Overrides nl_func_def_start when there is only one parameter.
//nl_func_def_start_single        = ignore      // original -> add

// -- CHANGES --

// DOES NOT CHANGE
RemoteInvalidArgumentError()
    : RemoteInvalidArgumentError("The value of a parameter passed has an illegal value")
{
}

// ALSO DOES NOT CHANGE
RemoteInvalidArgumentError(const char* msg)
    : RpcRemoteException(RemoteExceptionCode_t::REMOTE_EX_INVALID_ARGUMENT, msg)
{
}

// SHOULD BE
RemoteInvalidArgumentError(
        const char* msg)
    : RpcRemoteException(RemoteExceptionCode_t::REMOTE_EX_INVALID_ARGUMENT, msg)
{
}

```